### PR TITLE
fixed Curve::Intersect() about z component.

### DIFF
--- a/src/shapes/curve.cpp
+++ b/src/shapes/curve.cpp
@@ -145,8 +145,10 @@ bool Curve::Intersect(const Ray &r, Float *tHit,
     Float L0 = 0;
     for (int i = 0; i < 2; ++i)
         L0 = std::max(
-            L0, std::max(std::abs(cp[i].x - 2 * cp[i + 1].x + cp[i + 2].x),
-                         std::abs(cp[i].y - 2 * cp[i + 1].y + cp[i + 2].y)));
+            L0, std::max(
+                    std::max(std::abs(cp[i].x - 2 * cp[i + 1].x + cp[i + 2].x),
+                             std::abs(cp[i].y - 2 * cp[i + 1].y + cp[i + 2].y)),
+                    std::abs(cp[i].z - 2 * cp[i + 1].z + cp[i + 2].z)));
     Float eps =
         std::max(common->width[0], common->width[1]) * .05f;  // width / 20
 #define LOG4(x) (std::log(x) * 0.7213475108f)


### PR DESCRIPTION
This fix introduces a subexpression about z as described in Errata (http://eaflux.com/index.html.en):

> Page 2, bottom right: If control points are placed non-uniformly in ray direction, the resulting v parameter may have a large margin of error because the algorithm computes v in 2D space. To compensate this, we should add a subexpression about z in the maximum depth computation. (Thanks to Emil Kirichev)

Anyway, thank you very much for implementing the algorithm!
