### PR TITLE
Support for Windows+MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,47 +8,39 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 ENDIF()
 
-# src/core/*.cpp are handled differently due to
-# the presence of yacc/lex generated files which
-# may be optionally generated, especially on
-# Windows which is a pain
-IF (WIN32)
-  SET ( PBRT_YACC_LEX_SOURCE
-    src/core/pbrtlex.cpp
-    src/core/pbrtparse.cpp
-    )
-ELSE()
-  FIND_PACKAGE ( BISON REQUIRED )
-  
-  IF(BISON_FOUND)
-    SET(BisonOutput ${CMAKE_BINARY_DIR}/pbrtparser.cpp)
-    ADD_CUSTOM_COMMAND(
-      OUTPUT ${BisonOutput}
-      COMMAND ${BISON_EXECUTABLE} -d -v -t
-              --output=${BisonOutput}
-              ${CMAKE_SOURCE_DIR}/src/core/pbrtparse.yy
-      COMMENT "Generating pbrtparser.cpp"
-      )
-  ENDIF()
+# Optionally use Bison and Flex to regenerate parser files
+# Use pregenerated files otherwise (may be outdated)
+FIND_PACKAGE ( BISON )
+FIND_PACKAGE ( FLEX )
+IF(BISON_FOUND AND FLEX_FOUND)
+  SET(BisonOutput ${CMAKE_BINARY_DIR}/pbrtparser.cpp)
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${BisonOutput}
+    COMMAND ${BISON_EXECUTABLE} -d -v -t
+            --output=${BisonOutput}
+            ${CMAKE_SOURCE_DIR}/src/core/pbrtparse.yy
+    COMMENT "Generating pbrtparser.cpp"
+  )
 
-  FIND_PACKAGE ( FLEX REQUIRED )
-  IF(FLEX_FOUND)
-    SET(FlexOutput ${CMAKE_BINARY_DIR}/pbrtlex.cpp)
-    ADD_CUSTOM_COMMAND(
-      OUTPUT ${FlexOutput}
-      COMMAND ${FLEX_EXECUTABLE}
-              --outfile=${FlexOutput}
-              ${CMAKE_SOURCE_DIR}/src/core/pbrtlex.ll
-      COMMENT "Generating pbrtlex.cpp"
-      )
-  ENDIF()
+  SET(FlexOutput ${CMAKE_BINARY_DIR}/pbrtlex.cpp)
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${FlexOutput}
+    COMMAND ${FLEX_EXECUTABLE}
+            --outfile=${FlexOutput}
+            ${CMAKE_SOURCE_DIR}/src/core/pbrtlex.ll
+    COMMENT "Generating pbrtlex.cpp"
+  )
 
   SET ( PBRT_YACC_LEX_SOURCE
     ${BisonOutput}
     ${FlexOutput}
     )
-
-ENDIF ()
+ELSE()
+  SET ( PBRT_YACC_LEX_SOURCE
+    src/core/pbrtlex.cpp
+    src/core/pbrtparse.cpp
+    )
+ENDIF()
 
 SET ( PBRT_CORE_SOURCE
   src/core/api.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ PROJECT ( PBRT-V3 )
 
 ENABLE_TESTING()
 
-IF (APPLE)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 ENDIF()
 
 # src/core/*.cpp are handled differently due to

--- a/src/core/fileutil.cpp
+++ b/src/core/fileutil.cpp
@@ -47,7 +47,7 @@ static std::string searchDirectory;
 bool IsAbsolutePath(const std::string &filename) {
     if (filename.size() == 0) return false;
     return (filename[0] == '\\' || filename[0] == '/' ||
-            filename.find(':') != string::npos);
+            filename.find(':') != std::string::npos);
 }
 
 std::string AbsolutePath(const std::string &filename) {

--- a/src/core/fileutil.cpp
+++ b/src/core/fileutil.cpp
@@ -33,6 +33,7 @@
 #include "stdafx.h"
 
 // core/fileutil.cpp*
+#include "pbrt.h"
 #include "fileutil.h"
 #include <cstdlib>
 #include <climits>

--- a/src/core/parallel.cpp
+++ b/src/core/parallel.cpp
@@ -50,7 +50,7 @@
 
 // Parallel Local Definitions
 static std::vector<std::thread> threads;
-static bool shutdown = false;
+static bool pbrtShutdown = false;
 static THREAD_LOCAL int threadIndex;
 class ParallelForLoop;
 static ParallelForLoop *workList = nullptr;
@@ -98,7 +98,7 @@ static std::condition_variable workListCondition;
 static void workerThreadFunc(int tIndex) {
     threadIndex = tIndex;
     std::unique_lock<std::mutex> lock(workListMutex);
-    while (!shutdown) {
+    while (!pbrtShutdown) {
         if (!workList) {
             // Sleep until there are more tasks to run
             workListCondition.wait(lock);
@@ -448,11 +448,11 @@ void TerminateWorkerThreads() {
 
     {
         std::lock_guard<std::mutex> lock(workListMutex);
-        shutdown = true;
+        pbrtShutdown = true;
         workListCondition.notify_all();
     }
 
     for (std::thread &thread : threads) thread.join();
     threads.erase(threads.begin(), threads.end());
-    shutdown = false;
+    pbrtShutdown = false;
 }

--- a/src/core/parallel.cpp
+++ b/src/core/parallel.cpp
@@ -36,7 +36,9 @@
 #include "parallel.h"
 #include "memory.h"
 #include "stats.h"
-#ifndef PBRT_IS_WINDOWS
+#ifdef PBRT_IS_WINDOWS
+#include <windows.h>
+#else
 #include <sys/sysctl.h>
 #endif  // PBRT_IS_WINDOWS
 #ifdef PBRT_IS_LINUX

--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -49,6 +49,11 @@
 #elif defined(__OpenBSD__)
 #define PBRT_IS_OPENBSD
 #endif
+#if defined(_MSC_VER)
+#define PBRT_IS_MSVC
+#elif defined(__MINGW32__) // Defined for both 32 bit/64 bit MinGW
+#define PBRT_IS_MINGW
+#endif
 
 // Global Include Files
 #include <type_traits>
@@ -72,7 +77,7 @@
 
 // Platform-specific definitions
 #include <stdint.h>
-#if defined(PBRT_IS_WINDOWS)
+#if defined(PBRT_IS_MSVC)
 #include <float.h>
 #pragma warning(disable : 4305)  // double constant assigned to float
 #pragma warning(disable : 4244)  // int -> float conversion
@@ -198,7 +203,7 @@ static const Float Inv2Pi = 0.15915494309189533577;
 static const Float Inv4Pi = 0.07957747154594766788;
 static const Float PiOver2 = 1.57079632679489661923;
 static const Float PiOver4 = 0.785398163397448309616;
-#if defined(PBRT_IS_WINDOWS)
+#if defined(PBRT_IS_MSVC)
 #define alloca _alloca
 #endif
 #ifndef PBRT_L1_CACHE_LINE_SIZE
@@ -284,7 +289,7 @@ inline Float gamma(int n) {
 
 inline bool AtomicCompareAndExchange(volatile int32_t *v, int32_t newValue,
                                      int32_t oldValue) {
-#if defined(_MSC_VER)
+#if defined(PBRT_IS_MSVC)
     return _InterlockedCompareExchange(reinterpret_cast<volatile long *>(v),
                                        newValue, oldValue) == oldValue;
 #else
@@ -294,7 +299,7 @@ inline bool AtomicCompareAndExchange(volatile int32_t *v, int32_t newValue,
 
 inline bool AtomicCompareAndExchange(volatile int64_t *v, int64_t newValue,
                                      int64_t oldValue) {
-#if defined(_MSC_VER)
+#if defined(PBRT_IS_MSVC)
     return _InterlockedCompareExchange64(
                reinterpret_cast<volatile __int64 *>(v), newValue, oldValue) ==
            oldValue;

--- a/src/core/pbrtlex.ll
+++ b/src/core/pbrtlex.ll
@@ -43,7 +43,7 @@
 
 struct ParamArray;
 
-#if defined(PBRT_IS_WINDOWS)
+#if defined(PBRT_IS_MSVC)
 #pragma warning(disable:4244)
 #pragma warning(disable:4065)
 #pragma warning(disable:4018)

--- a/src/core/pbrtparse.yy
+++ b/src/core/pbrtparse.yy
@@ -36,11 +36,11 @@
 #include "paramset.h"
 #include <stdarg.h>
 
-#ifdef PBRT_IS_WINDOWS
+#ifdef PBRT_IS_MSVC
 #pragma warning(disable:4065)
 #pragma warning(disable:4996)
 #pragma warning(disable:4018)
-#endif // PBRT_IS_WINDOWS
+#endif // PBRT_IS_MSVC
 
 extern int yylex();
 extern void include_push(char *filename);

--- a/src/core/reflection.h
+++ b/src/core/reflection.h
@@ -473,7 +473,7 @@ class KajiyaKay : public BxDF {
           Kd(kd),
           Ks(ks) {
         Float e = (Float)1. / roughness;
-        if (e > 10000.f || isnan(e)) e = 10000.f;
+        if (e > 10000.f || std::isnan(e)) e = 10000.f;
         exponent = e;
     }
     Spectrum f(const Vector3f &wo, const Vector3f &wi) const;

--- a/src/core/rng.h
+++ b/src/core/rng.h
@@ -43,7 +43,7 @@
 #include "pbrt.h"
 
 // Random Number Declarations
-#ifdef PBRT_IS_WINDOWS
+#ifdef PBRT_IS_MSVC
 // sadly, MSVC2008 (at least) doesn't support hexidecimal fp constants...
 static const Float OneMinusEpsilon = 0.9999999403953552f;
 #else

--- a/src/ext/tinyexr.cpp
+++ b/src/ext/tinyexr.cpp
@@ -4148,7 +4148,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h,
 #include <stdio.h>
 #include <sys/stat.h>
 
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#if defined(_MSC_VER)
 static FILE *mz_fopen(const char *pFilename, const char *pMode) {
     FILE *pFile = NULL;
     fopen_s(&pFile, pFilename, pMode);

--- a/src/integrators/bdpt.cpp
+++ b/src/integrators/bdpt.cpp
@@ -159,7 +159,7 @@ int GenerateCameraSubpath(const Scene &scene, Sampler &sampler,
     path[0] = Vertex(VertexType::Camera, EndpointInteraction(&camera, ray),
                      Spectrum(1.0f));
     return RandomWalk(scene, ray, sampler, arena, rayWeight,
-                      camera.Pdf(path[0].ei, ray.d), maxdepth - 1,
+                      camera.Pdf(path[0].interaction.ei, ray.d), maxdepth - 1,
                       TransportMode::Radiance, path + 1) +
            1;
 }
@@ -407,8 +407,8 @@ Spectrum ConnectBDPT(const Scene &scene, Vertex *lightSubpath,
         if (vt.IsLight()) {
             Spectrum Le;
             if (vt.type == VertexType::Surface) {
-                Le = vt.isect.primitive->GetAreaLight()->L(vt.isect,
-                                                           vt.isect.wo);
+                Le = vt.interaction.isect.primitive->GetAreaLight()->L(vt.interaction.isect,
+                                                                       vt.interaction.isect.wo);
             } else {
                 for (const auto &light : scene.lights)
                     Le += light->Le(

--- a/src/tests/exr.cpp
+++ b/src/tests/exr.cpp
@@ -1,5 +1,6 @@
 
 #include "tests/gtest/gtest.h"
+#include <stdint.h>
 #include <cmath>
 
 #include "pbrt.h"
@@ -7,21 +8,21 @@
 #include "ext/tinyexr.h"
 
 union FP32 {
-    uint u;
+    uint32_t u;
     float f;
     struct {
-        uint Mantissa : 23;
-        uint Exponent : 8;
-        uint Sign : 1;
+        uint32_t Mantissa : 23;
+        uint32_t Exponent : 8;
+        uint32_t Sign : 1;
     };
 };
 
 union FP16 {
-    unsigned short u;
+    uint16_t u;
     struct {
-        uint Mantissa : 10;
-        uint Exponent : 5;
-        uint Sign : 1;
+        uint32_t Mantissa : 10;
+        uint32_t Exponent : 5;
+        uint32_t Sign : 1;
     };
 };
 
@@ -37,7 +38,7 @@ static FP32 half_to_float_full(FP16 h)
     if (h.Exponent == 0) { // Denormal (will convert to normalized)
       // Adjust mantissa so it's normalized (and keep track of exp adjust)
       int e = -1;
-      uint m = h.Mantissa;
+      uint32_t m = h.Mantissa;
       do {
         e++;
         m <<= 1;

--- a/src/tools/bsdftest.cpp
+++ b/src/tools/bsdftest.cpp
@@ -240,8 +240,8 @@ int main(int argc, char* argv[]) {
 
                 if (!validSample) {
                     outsideSamples++;
-                } else if (pdf == 0.f || isnan(pdf) || redF < 0 ||
-                           isnan(redF)) {
+                } else if (pdf == 0.f || std::isnan(pdf) || redF < 0 ||
+                           std::isnan(redF)) {
                     if (badSamples == warningTarget) {
                         fprintf(stderr,
                                 "warning %d, bad sample %d! "


### PR DESCRIPTION
Hi,

This PR contains some changes required to get PBRT to compile on Windows using MinGW-w64 (gcc 4.9.1). MinGW sort of sits between the linux build and the MSVC build, in that it tests the PBRT_IS_WINDOWS branches while still using gcc, and I find it a good starting point when porting something to Windows. From what I can tell, the renderer seems to work - all the tests are passing, and I can render the furry bunny scene. I'm not sure whether pbrt-v3 has been compiled on gcc before, and at least some of the fixes should apply to gcc on Linux as well.

There were a few minor issues, most of which were easily corrected. A few things to note
* gcc does not allow for anonymous generalized unions - they have to be named. This affects the interaction union in bdpt.h, which I had to change to a named union member. In order to get this to work with the ei/mi/isect constructors, an overloaded union constructor had to be added that initializes the proper union member. Naming can be argued, let me know if you want it to be called something else.
* There are a large number of unsigned/signed comparison warnings. Most of them can be fixed, but some are in tinyexr, which I would rather not touch. You can either decide to disable this warning, or to fix the spots that cause compiler warnings and open a PR for tinyexr.
* MinGW complains about using %lld in printf and its variants. I'm not sure whether it is actually unsupported or whether it's being pedantic about non-standard flags, so this might be worth looking into. In general, most of the printf uses in the code could also be replaced by tinyformat, a single-file C++11 version of printf and co. that uses std::string and variadic templates, which I found immensely useful.
* On Windows, stdout is block buffered, not line buffered as on linux, so some of the testing tools (e.g. bsdftest) won't output anything until they've hit some unspecified number of output bytes (usually about 1k characters). This could be fixed by replacing '\n' with std::endl or flushing stdout explicitly after each line

Having had a short look at the code, I also found some issues that could hinder compilation on MSVC. I worked on a similar cross-platform C++11 project before, so some suggestions:
* MSVC 2013 has no support for constexpr. I worked around this by using a CONSTEXPR macro in my code instead, which is defined as either const or constexpr in the build script, depending on the compiler. This does not work when the expression actually has to be constexpr (e.g. when used as a template parameter), but it covers most use cases when constexpr is simply used for performance reasons.
* MSVC 2013 does not allow for generalized unions, and again, BDPT is in trouble (I ran into exactly the same issue when implementing BDPT in Tungsten). To get this to work in MSVC, each union member needs to have a trivial default constructor (i.e. Foo() = default). This is a bit unfortunate, since it does not allow you to initialize interactions to a valid state when they're used on their own, but there does not seem to be a different way.

I saw some people were already working on a CMake script/MSVC build, so in the interest of avoiding duplicate work I will leave it here. Let me know if you have any questions/suggestions.