### PR TITLE
Branch new vs2013 build

### DIFF
--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -90,7 +90,7 @@
 // Global Macros
 #define ALLOCA(TYPE, COUNT) (TYPE *) alloca((COUNT) * sizeof(TYPE))
 #ifdef PBRT_IS_MSVC
-#define THREAD_LOCAL thread_local
+#define THREAD_LOCAL __declspec(thread)
 #else
 #define THREAD_LOCAL __thread
 #endif

--- a/src/core/unistd.h
+++ b/src/core/unistd.h
@@ -1,0 +1,41 @@
+
+/*
+    pbrt source code Copyright(c) 1998-2012 Matt Pharr and Greg Humphreys.
+
+    This file is part of pbrt.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+    IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+    TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+#ifndef PBRT_WIN32_UNISTD_H
+#define PBRT_WIN32_UNISTD_H
+
+// win32/unistd.h*
+// foo to cygwin
+#ifdef _MSC_VER
+static int isatty(int) { return 0; }
+#endif
+
+#endif // PBRT_WIN32_UNISTD_H


### PR DESCRIPTION
Hi

This PR contains some fixes that addresses the following issues for compilation errors in MSVC 2013.

1. Thread Local Storage (TLS) declaration for MSVC is given according to https://msdn.microsoft.com/en-us/library/6yh4a9k1.aspx

2. unistd.h file is not present on windows and I have used the file from pbrt v2. I have added a guard to the actual function isatty() so that it doesnt create any problems in unix/linux distributions. I dont have access to a linux machine and it would be great if someone could check if this hack creates issues.

3. Currently binary literals are not supported in MSVC2013 and hence I've converted all the literals to actual hex values.

4. The compilation fails for other kinds of power literals also and I think I saw a PR containing fixes for this using ldexpr() functions. I am not adding the same here in this PR since it would be duplication of effort. 

Currently one big issue with compilation on windows is with respect to the isNaN() function from std namespace. There is a ambiguous call to fpclassify() for the Point and Vector classes when the template argument is of integer type.