### PR TITLE
Added compilation fix for GCC 4.9.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,8 @@ ADD_LIBRARY ( pbrt STATIC
   ${PBRT_SOURCE}
   )
 
+FIND_PACKAGE ( Threads )
+
 # Main renderer
 ADD_EXECUTABLE ( pbrt_exe
   src/main/pbrt.cpp
@@ -171,6 +173,7 @@ SET_TARGET_PROPERTIES ( pbrt_exe
 
 TARGET_LINK_LIBRARIES ( pbrt_exe
   pbrt
+  ${CMAKE_THREAD_LIBS_INIT}
   )
 
 # Tools


### PR DESCRIPTION
Added fix for GCC 4.9.3, as pbrt_test was failing to build, and pbrt would not run.