### PR TITLE
Add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+compiler: gcc
+sudo: required
+install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - sudo apt-get install -yq build-essential gcc-4.8 g++-4.8 cmake make bison flex libpthread-stubs0-dev
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+  - echo 2 | sudo update-alternatives --config gcc
+after_install:
+  - g++ --version
+script:
+  - cmake -G 'Unix Makefiles'
+  - make -j2
+  - ./pbrt_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ IF(MSVC)
   ADD_DEFINITIONS (/D _CRT_SECURE_NO_WARNINGS)
 ENDIF()
 
-FIND_PACKAGE ( THREADS )
+FIND_PACKAGE ( Threads )
 
 # Optionally use Bison and Flex to regenerate parser files
 # Use pregenerated files otherwise (may be outdated)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:12.04
+MAINTAINER Amit Bakshi <ambakshi@gmail.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -yq
+RUN apt-get install -yq python-software-properties
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get update -yq
+RUN apt-get install -yq build-essential gcc-4.8 g++-4.8 cmake make bison flex libpthread-stubs0-dev
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+RUN echo 2 | update-alternatives --config gcc
+ADD . /app
+WORKDIR /app/build
+RUN cmake -G 'Unix Makefiles' ..
+CMD ["/usr/bin/make","-j2"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 pbrt, Version 3
 ===============
 
+[![Build Status](https://travis-ci.org/ambakshi/pbrt-v3.svg?branch=master)](https://travis-ci.org/ambakshi/pbrt-v3)
+
 This repository holds the current snapshot of the source code to the new
 version of pbrt that will be described in the forthcoming third edition of
 *Physically Based Rendering: From Theory to Implementation*.  As before,
@@ -65,7 +67,7 @@ come once everything is finalized.)
     run ‘main.py’ to launch the visual layer editor.
 * Improved microfacet models: specular transmission through microfacets,
   and Heitz's improved importance sampling.
-* No external dependencies: thanks to 
+* No external dependencies: thanks to
 [Syoyo Fujita's tinyexr](https://github.com/syoyo/tinyexr),
 [Sean Barrett's stb_image_write.h](https://github.com/nothings/stb),
 [Diego Nehab's rply](http://www.impa.br/~diego/software/rply),
@@ -86,7 +88,7 @@ page](http://www.cmake.org/download/).
 
 * For command-line builds on Linux and OS X, once you have cmake installed,
 create a new directory for the build, change to that directory, and run
-`cmake <path to pbrt-v3>`. A Makefile will be created in that 
+`cmake <path to pbrt-v3>`. A Makefile will be created in that
 current directory.  Run `make -j4`, and pbrt and some additional tools will
 be built.
 * To make an XCode project file on OS X, run `cmake -G Xcode <path to
@@ -138,7 +140,7 @@ copy of the book to folks who make significant contributions.
 
 * Finding bugs: though we've tried to test thoroughly,
 there are certainly bugs in the code, and we'd like to find them before
-they are published in the book! The 
+they are published in the book! The
 [pbrt-v3 issue tracker](https://github.com/mmp/pbrt-v3/issues) is the best
 place to report anything suspicious you find.  Useful things to do include:
   * Running various scenes through the renderer and checking the results.
@@ -152,7 +154,7 @@ targets don't currently work.
 * Images and figures: we'd like to refresh many of the figures in the book,
 but probably won't have time to get to all of them. If you can spend some
 time on making a nice scene or two that we can use for figures, that'd be a
-huge help. Specific areas of interest include: 
+huge help. Specific areas of interest include:
   * Subsurface scattering: a human face, biological objects, ...
   * Showing off complex light transport using bidirectional path
   tracing.


### PR DESCRIPTION
- Fixed capitalization of 'THREADS' to 'Threads', because the cmake module is called FindThreads and cmake is unable to find FindTHREADS on a case sensitive file system (on Linux in my case)
- Add docker support to encapsulate the build dependencies
- Add Travis-CI support to automatically build pbrt when changes are made to the repo. You'll need to register the official pbrt repo on travis-ci and change the link in README.md to point to your travis status. You can see the output from the last build to my repo here: https://travis-ci.org/ambakshi/pbrt-v3/builds/71610488

