### PR TITLE
Resolve few problems for compiling in MSVC 2015

### DIFF
--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -77,9 +77,11 @@ RealisticCamera::RealisticCamera(const AnimatedTransform &CameraToWorld,
                 lensData[i + 3] = apertureDiameter;
             }
         }
-        elementInterfaces.push_back((LensElementInterface){
+
+        LensElementInterface lensInterface {
             lensData[i] * (Float).001, lensData[i + 1] * (Float).001,
-            lensData[i + 2], lensData[i + 3] * Float(.001) / Float(2.)});
+            lensData[i + 2], lensData[i + 3] * Float(.001) / Float(2.)};
+        elementInterfaces.push_back(lensInterface);
     }
 
     // Compute lens--film distance for given focus distance
@@ -92,11 +94,11 @@ RealisticCamera::RealisticCamera(const AnimatedTransform &CameraToWorld,
     // Compute exit pupil bounds at sampled points on the film
     int nSamples = 64;
     exitPupilBounds.resize(nSamples);
-    ParallelFor([&](int i) {
+    ParallelFor(static_cast<std::function<void(int)>>([&](int i) {
         Float r0 = (Float)i / (Float)(nSamples)*film->diagonal / 2;
         Float r1 = (Float)(i + 1) / (Float)(nSamples)*film->diagonal / 2;
         exitPupilBounds[i] = BoundExitPupil(r0, r1);
-    }, nSamples);
+    }), nSamples);
 }
 
 bool RealisticCamera::TraceLensesFromFilm(const Ray &ray, Ray *rOut) const {

--- a/src/core/bssrdf.cpp
+++ b/src/core/bssrdf.cpp
@@ -135,7 +135,7 @@ void ComputeBeamDiffusionBSSRDF(Float g, Float eta, BSSRDFTable *t) {
     t->radiusSamples[1] = 2.5e-3f;
     for (int i = 2; i < t->nRadiusSamples; ++i)
         t->radiusSamples[i] = t->radiusSamples[i - 1] * 1.2f;
-    ParallelFor([&](int i) {
+    ParallelFor(static_cast<std::function<void(int)>>([&](int i) {
         // Compute the diffusion profile for the _i_-th albedo sample
         Float rho = (1 - std::exp(-8 * i / (Float)(t->nRhoSamples - 1))) /
                     (1 - std::exp(-8));
@@ -154,7 +154,7 @@ void ComputeBeamDiffusionBSSRDF(Float g, Float eta, BSSRDFTable *t) {
             IntegrateCatmullRom(t->nRadiusSamples, t->radiusSamples.get(),
                                 &t->profile[i * t->nRadiusSamples],
                                 &t->profileCDF[i * t->nRadiusSamples]);
-    }, t->nRhoSamples);
+    }), t->nRhoSamples);
 }
 
 void SubsurfaceFromDiffuse(const BSSRDFTable &table, const Spectrum &Kd,

--- a/src/core/integrator.cpp
+++ b/src/core/integrator.cpp
@@ -263,7 +263,7 @@ void SamplerIntegrator::Render(const Scene &scene) {
     ProgressReporter reporter(nTiles.x * nTiles.y, "Rendering");
     {
         StatTimer timer(&renderingTime);
-        ParallelFor([&](Point2i tile) {
+        ParallelFor(static_cast<std::function<void(Point2i)>>([&](Point2i tile) {
             // Render section of image corresponding to _tile_
 
             // Allocate _MemoryArena_ for tile
@@ -336,7 +336,7 @@ void SamplerIntegrator::Render(const Scene &scene) {
             // Merge image tile into _Film_
             camera->film->MergeFilmTile(std::move(filmTile));
             reporter.Update();
-        }, nTiles);
+        }), nTiles);
         reporter.Done();
     }
 

--- a/src/core/lowdiscrepancy.cpp
+++ b/src/core/lowdiscrepancy.cpp
@@ -450,7 +450,11 @@ Float RadicalInverse(int baseIndex, uint64_t a) {
     switch (baseIndex) {
     case 0:
         // Compute base-2 radical inverse
+#ifdef _MSC_VER
+        return ReverseBits64(a) * ldexp(1.0f, -64);
+#else
         return ReverseBits64(a) * 0x1p-64;
+#endif
     case 1:
         return RadicalInverseSpecialized<3>(a);
     case 2:

--- a/src/core/lowdiscrepancy.h
+++ b/src/core/lowdiscrepancy.h
@@ -104,7 +104,7 @@ inline uint32_t ReverseMultiplyGenerator(const uint32_t *C, uint32_t a) {
 
 inline Float SampleGeneratorMatrix(const uint32_t *C, uint32_t a,
                                    uint32_t scramble = 0) {
-    return (ReverseMultiplyGenerator(C, a) ^ scramble) * 0x1p-32f /* 1/2^32 */;
+    return (ReverseMultiplyGenerator(C, a) ^ scramble) * OneOverTwoToThe32;
 }
 
 inline uint32_t GrayCode(uint32_t v) { return (v >> 1) ^ v; }
@@ -113,7 +113,7 @@ inline void GrayCodeSample(const uint32_t *C, uint32_t n, uint32_t scramble,
                            Float *p) {
     uint32_t v = scramble;
     for (uint32_t i = 0; i < n; ++i) {
-        p[i] = v * 0x1p-32f /* 1/2^32 */;
+        p[i] = v * OneOverTwoToThe32;
         v ^= C[31 - CountTrailingZeros(i + 1)];
     }
 }
@@ -122,8 +122,8 @@ inline void GrayCodeSample(const uint32_t *C0, const uint32_t *C1, uint32_t n,
                            const Point2i &scramble, Point2f *p) {
     uint32_t v[2] = {(uint32_t)scramble.x, (uint32_t)scramble.y};
     for (uint32_t i = 0; i < n; ++i) {
-        p[i].x = v[0] * 0x1p-32f;
-        p[i].y = v[1] * 0x1p-32f;
+        p[i].x = v[0] * OneOverTwoToThe32;
+        p[i].y = v[1] * OneOverTwoToThe32;
         v[0] ^= C0[31 - CountTrailingZeros(i + 1)];
         v[1] ^= C1[31 - CountTrailingZeros(i + 1)];
     }
@@ -213,7 +213,7 @@ inline float SobolSampleFloat(int64_t a, int dimension, uint32_t scramble) {
     for (int i = dimension * kSobolMatrixSize + kSobolMatrixSize - 1; a != 0;
          a >>= 1, --i)
         if (a & 1) v ^= SobolMatrices32[i];
-    return v * 0x1p-32f; /* 1/2^32 */
+    return v * OneOverTwoToThe32;
 }
 
 inline double SobolSampleDouble(int64_t index, int dimension,

--- a/src/core/pbrt.h
+++ b/src/core/pbrt.h
@@ -81,6 +81,7 @@
 #if defined(PBRT_IS_MSVC)
 #include <float.h>
 #include <intrin.h>
+#include <functional>            // used to resolve a trailing return type error C3551
 #pragma warning(disable : 4305)  // double constant assigned to float
 #pragma warning(disable : 4244)  // int -> float conversion
 #pragma warning(disable : 4267)  // size_t -> unsigned int conversion
@@ -208,6 +209,11 @@ static const Float Inv4Pi = 0.07957747154594766788;
 static const Float PiOver2 = 1.57079632679489661923;
 static const Float PiOver4 = 0.78539816339744830961;
 static const Float Sqrt2 = 1.41421356237309504880;
+#ifdef _MSC_VER
+static const Float OneOverTwoToThe32 = ldexp(1.0f, -32);
+#else
+static const Float OneOverTwoToThe32 = 0x1p-32f;
+#endif
 #if defined(PBRT_IS_MSVC)
 #define alloca _alloca
 #endif

--- a/src/core/pbrtlex.cpp
+++ b/src/core/pbrtlex.cpp
@@ -801,7 +801,11 @@ void include_pop() {
  * down here because we want the user's section 1 to have been scanned first.
  * The user has a chance to override it with an option.
  */
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 #endif
 
 #ifndef YY_EXTRA_TYPE

--- a/src/core/rng.h
+++ b/src/core/rng.h
@@ -83,7 +83,7 @@ class RNG {
         }
     }
     Float UniformFloat() {
-        return std::min(OneMinusEpsilon, UniformUInt32() * 0x1p-32f);
+        return std::min(OneMinusEpsilon, UniformUInt32() * OneOverTwoToThe32);
     }
     template <typename Iterator>
     void Shuffle(Iterator begin, Iterator end) {

--- a/src/integrators/bdpt.cpp
+++ b/src/integrators/bdpt.cpp
@@ -312,7 +312,8 @@ void BDPTIntegrator::Render(const Scene &scene) {
     // Render and write the output image to disk
     {
         StatTimer timer(&renderingTime);
-        ParallelFor([&](const Point2i tile) {
+        ParallelFor(static_cast<std::function<void(Point2i)>>(
+            [&](const Point2i tile) {
             // Render a single tile using BDPT
             MemoryArena arena;
             int seed = tile.y * nXTiles + tile.x;
@@ -377,7 +378,7 @@ void BDPTIntegrator::Render(const Scene &scene) {
             }
             film->MergeFilmTile(std::move(filmTile));
             reporter.Update();
-        }, Point2i(nXTiles, nYTiles));
+        }), Point2i(nXTiles, nYTiles));
         reporter.Done();
     }
     film->WriteImage(1.0f / sampler->samplesPerPixel);

--- a/src/integrators/mlt.cpp
+++ b/src/integrators/mlt.cpp
@@ -169,7 +169,7 @@ void MLTIntegrator::Render(const Scene &scene) {
     std::vector<Float> bootstrapWeights(nBootstrapSamples, 0);
     {
         ProgressReporter progress(nBootstrap, "Generating bootstrap paths");
-        ParallelFor([&](int i) {
+        ParallelFor(static_cast<std::function<void(int)>>([&](int i) {
             // Generate _i_th bootstrap sample
             MemoryArena arena;
             for (int depth = 0; depth <= maxDepth; ++depth) {
@@ -182,7 +182,7 @@ void MLTIntegrator::Render(const Scene &scene) {
                 arena.Reset();
             }
             progress.Update();
-        }, nBootstrap, 4096);
+        }), nBootstrap, 4096);
         progress.Done();
     }
     Distribution1D bootstrap(&bootstrapWeights[0], nBootstrapSamples);
@@ -195,7 +195,7 @@ void MLTIntegrator::Render(const Scene &scene) {
     {
         StatTimer timer(&renderingTime);
         ProgressReporter progress(nTotalMutations / 100, "Rendering");
-        ParallelFor([&](int i) {
+        ParallelFor(static_cast<std::function<void(int)>>([&](int i) {
             int64_t nChainMutations =
                 std::min((i + 1) * nTotalMutations / nChains, nTotalMutations) -
                 i * nTotalMutations / nChains;
@@ -242,7 +242,7 @@ void MLTIntegrator::Render(const Scene &scene) {
                 if (i % 100 == 0) progress.Update();
                 arena.Reset();
             }
-        }, nChains);
+        }), nChains);
         progress.Done();
     }
 

--- a/src/tools/obj2pbrt.cpp
+++ b/src/tools/obj2pbrt.cpp
@@ -18,6 +18,10 @@
 #ifndef _TINY_OBJ_LOADER_H
 #define _TINY_OBJ_LOADER_H
 
+#ifdef _MSC_VER >= 1800
+#include <algorithm>
+#endif
+
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Hi,

This set of changes are trying to resolve following compiling problems in MSVC 2015:
* Replace hexadecimal floating point literals 0x1p-32f with [ldexp](http://stackoverflow.com/questions/23826876/convert-hexadecimal-floating-point-constant)
* Fix ambiguous calls to overloaded function ParallelFor with explicit cast. It seems that std::function has a [greedy template constructor](http://stackoverflow.com/questions/22542780/c11-auto-stdfunction-and-ambiguous-call-to-overloaded-function) in MSVC and fails to do overload resolution properly.