### PR TITLE
Small tweak for VS2105 debug build: Fix template ambiguity with fpclassify in isnan

### DIFF
--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -43,11 +43,11 @@
 #include "pbrt.h"
 
 template<typename T>
-bool isNaN(const T x){
+inline bool isNaN(const T x){
     return std::isnan(x);
 }
 template<>
-constexpr bool isNaN(const int x){
+inline bool isNaN(const int x){
     return false;
 }
 

--- a/src/core/geometry.h
+++ b/src/core/geometry.h
@@ -42,6 +42,15 @@
 // core/geometry.h*
 #include "pbrt.h"
 
+template<typename T>
+bool isNaN(const T x){
+    return std::isnan(x);
+}
+template<>
+constexpr bool isNaN(const int x){
+    return false;
+}
+
 // Vector Declarations
 template <typename T>
 class Vector2 {
@@ -49,7 +58,7 @@ class Vector2 {
     // Vector2 Public Methods
     Vector2() { x = y = 0; }
     Vector2(T xx, T yy) : x(xx), y(yy) { Assert(!HasNaNs()); }
-    bool HasNaNs() const { return std::isnan(x) || std::isnan(y); }
+    bool HasNaNs() const { return isNaN(x) || isNaN(y); }
     explicit Vector2(const Point2<T> &p);
     explicit Vector2(const Point3<T> &p);
 #ifndef NDEBUG
@@ -99,7 +108,7 @@ class Vector2 {
     Vector2<T> operator*(T f) const { return Vector2<T>(f * x, f * y); }
 
     Vector2<T> &operator*=(T f) {
-        Assert(!std::isnan(f));
+        Assert(!isNaN(f));
         x *= f;
         y *= f;
         return *this;
@@ -155,7 +164,7 @@ class Vector3 {
     Vector3() { x = y = z = 0; }
     Vector3(T x, T y, T z) : x(x), y(y), z(z) { Assert(!HasNaNs()); }
     bool HasNaNs() const {
-        return std::isnan(x) || std::isnan(y) || std::isnan(z);
+        return isNaN(x) || isNaN(y) || isNaN(z);
     }
     explicit Vector3(const Point3<T> &p);
 #ifndef NDEBUG
@@ -210,7 +219,7 @@ class Vector3 {
     }
     Vector3<T> operator*(T s) const { return Vector3<T>(s * x, s * y, s * z); }
     Vector3<T> &operator*=(T s) {
-        Assert(!std::isnan(s));
+        Assert(!isNaN(s));
         x *= s;
         y *= s;
         z *= s;
@@ -357,7 +366,9 @@ class Point2 {
     }
     bool operator==(const Point2<T> &p) const { return x == p.x && y == p.y; }
     bool operator!=(const Point2<T> &p) const { return x != p.x || y != p.y; }
-    bool HasNaNs() const { return std::isnan(x) || std::isnan(y); }
+    bool HasNaNs() const {
+        return isNaN(x) || isNaN(y);
+    }
 
     // Point2 Public Data
     T x, y;
@@ -473,7 +484,7 @@ class Point3 {
         return x != p.x || y != p.y || z != p.z;
     }
     bool HasNaNs() const {
-        return std::isnan(x) || std::isnan(y) || std::isnan(z);
+        return isNaN(x) || isNaN(y) || isNaN(z);
     }
     Point3<T> operator-() const { return Point3<T>(-x, -y, -z); }
 
@@ -519,7 +530,7 @@ class Normal3 {
         return *this;
     }
     bool HasNaNs() const {
-        return std::isnan(x) || std::isnan(y) || std::isnan(z);
+        return isNaN(x) || isNaN(y) || isNaN(z);
     }
     Normal3<T> operator*(T f) const { return Normal3<T>(f * x, f * y, f * z); }
 
@@ -788,7 +799,7 @@ class Ray {
         : o(o), d(d), tMax(tMax), time(time), medium(medium) {}
     Point3f operator()(Float t) const { return o + d * t; }
     bool HasNaNs() const {
-        return (o.HasNaNs() || d.HasNaNs() || std::isnan(tMax));
+        return (o.HasNaNs() || d.HasNaNs() || isNaN(tMax));
     }
     friend std::ostream &operator<<(std::ostream &os, const Ray &r) {
         os << "[o=" << r.o << ", d=" << r.d << ", tMax=" << r.tMax


### PR DESCRIPTION
This last tweak gets the debug build compiling as well in VS2015, previously the calls to `std::isnan` with an int from the Point2i specialization would fail due to ambiguity in some standard library template instantiation. Interestingly enough this doesn't happen in the release build, so this may not be much of a priority.

Here's the actual error:
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.10150.0\ucrt\math.h(403): error C2668: 'fpclassify': ambiguous call to overloaded function
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10150.0\ucrt\math.h(288): note: could be 'int fpclassify(long double) throw()'
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10150.0\ucrt\math.h(283): note: or       'int fpclassify(double) throw()'
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10150.0\ucrt\math.h(278): note: or       'int fpclassify(float) throw()'
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10150.0\ucrt\math.h(403): note: while trying to match the argument list '(int)'
2>  c:\users\will\repos\pbrt-v3\src\core\geometry.h(360): note: see reference to function template instantiation 'bool isnan<T>(_Ty) throw()' being compiled
2>          with
2>          [
2>              T=int,
2>              _Ty=int
2>          ]
2>  c:\users\will\repos\pbrt-v3\src\core\geometry.h(360): note: while compiling class template member function 'bool Point2<int>::HasNaNs(void) const'
2>  c:\users\will\repos\pbrt-v3\src\core\geometry.h(277): note: see reference to function template instantiation 'bool Point2<int>::HasNaNs(void) const' being compiled
2>  c:\users\will\repos\pbrt-v3\src\core\geometry.h(777): note: see reference to class template instantiation 'Point2<int>' being compiled
2>  camera.cpp
```

I wasn't sure where you'd want this function to go so I've just put it at the top of geometry.h