### PR TITLE
Fix order of arguments passed to StratifiedSampler constructor

### DIFF
--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -79,5 +79,5 @@ StratifiedSampler *CreateStratifiedSampler(const ParamSet &params) {
     int ysamp = params.FindOneInt("ysamples", 4);
     int sd = params.FindOneInt("dimensions", 4);
     if (PbrtOptions.quickRender) xsamp = ysamp = 1;
-    return new StratifiedSampler(xsamp, ysamp, sd, jitter);
+    return new StratifiedSampler(xsamp, ysamp, jitter, sd);
 }


### PR DESCRIPTION
Minor change to CreateStratifiedSampler() so that the `jitter` and `sd` arguments are passed to the StratifiedSampler constructor in the correct order.