### PR TITLE
Improve error handling for missing lenses and other integrator load failures

### DIFF
--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -711,7 +711,7 @@ RealisticCamera *CreateRealisticCamera(const ParamSet &params,
     if (lensData.size() % 4 != 0) {
         Error("Excess values in lens specification file \"%s\"; "
             "must be multiple-of-four values, read %d.",
-            lensFile, (int)lensData.size());
+            lensFile.c_str(), (int)lensData.size());
         return nullptr;
     }
 

--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -49,23 +49,10 @@ STAT_PERCENT("Camera/Rays vignetted by lens system", vignettedRays, totalRays);
 RealisticCamera::RealisticCamera(const AnimatedTransform &CameraToWorld,
                                  Float shutterOpen, Float shutterClose,
                                  Float apertureDiameter, Float focusDistance,
-                                 bool simpleWeighting, const char *lensFile,
+                                 bool simpleWeighting, std::vector<Float> &lensData,
                                  Film *film, const Medium *medium)
     : Camera(CameraToWorld, shutterOpen, shutterClose, film, medium),
       simpleWeighting(simpleWeighting) {
-    // Load element data from lens description file
-    std::vector<Float> lensData;
-    if (ReadFloatFile(lensFile, &lensData) == false) {
-        Error("Error reading lens specification file \"%s\".", lensFile);
-        return;
-    }
-    if ((lensData.size() % 4) != 0) {
-        Error(
-            "Excess values in lens specification file \"%s\"; "
-            "must be multiple-of-four values, read %d.",
-            lensFile, (int)lensData.size());
-        return;
-    }
     for (int i = 0; i < (int)lensData.size(); i += 4) {
         if (lensData[i] == 0) {
             if (apertureDiameter > lensData[i + 3]) {
@@ -713,10 +700,22 @@ RealisticCamera *CreateRealisticCamera(const ParamSet &params,
     bool simpleWeighting = params.FindOneBool("simpleweighting", true);
     if (lensFile == "") {
         Error("No lens description file supplied!");
-        return NULL;
+        return nullptr;
+    }
+    // Load element data from lens description file
+    std::vector<Float> lensData;
+    if (!ReadFloatFile(lensFile.c_str(), &lensData)) {
+        Error("Error reading lens specification file \"%s\".", lensFile.c_str());
+        return nullptr;
+    }
+    if (lensData.size() % 4 != 0) {
+        Error("Excess values in lens specification file \"%s\"; "
+            "must be multiple-of-four values, read %d.",
+            lensFile, (int)lensData.size());
+        return nullptr;
     }
 
     return new RealisticCamera(cam2world, shutteropen, shutterclose,
                                apertureDiameter, focusDistance, simpleWeighting,
-                               lensFile.c_str(), film, medium);
+                               lensData, film, medium);
 }

--- a/src/cameras/realistic.h
+++ b/src/cameras/realistic.h
@@ -51,7 +51,7 @@ class RealisticCamera : public Camera {
     RealisticCamera(const AnimatedTransform &CameraToWorld, Float shutterOpen,
                     Float shutterClose, Float apertureDiameter,
                     Float focusDistance, bool simpleWeighting,
-                    const char *lensFile, Film *film, const Medium *medium);
+                    std::vector<Float> &lensData, Film *film, const Medium *medium);
     Float GenerateRay(const CameraSample &sample, Ray *) const;
 
   private:

--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -1181,12 +1181,16 @@ Scene *RenderOptions::MakeScene() {
 
 Integrator *RenderOptions::MakeIntegrator() const {
     std::shared_ptr<const Camera> camera(MakeCamera());
+    if (!camera) {
+        Error("Unable to create camera");
+        return nullptr;
+    }
 
     std::shared_ptr<Sampler> sampler =
         MakeSampler(SamplerName, SamplerParams, camera->film);
     if (!sampler) {
         Error("Unable to create sampler.");
-        exit(1);
+        return nullptr;
     }
 
     Integrator *integrator = nullptr;
@@ -1207,7 +1211,7 @@ Integrator *RenderOptions::MakeIntegrator() const {
         integrator = CreateSPPMIntegrator(IntegratorParams, camera);
     } else {
         Error("Integrator \"%s\" unknown.", IntegratorName.c_str());
-        exit(1);
+        return nullptr;
     }
 
     IntegratorParams.ReportUnused();
@@ -1224,14 +1228,10 @@ Camera *RenderOptions::MakeCamera() const {
     Film *film = MakeFilm(FilmName, FilmParams, std::move(filter));
     if (!film) {
         Error("Unable to create film.");
-        exit(1);
+        return nullptr;
     }
     Camera *camera = ::MakeCamera(CameraName, CameraParams, CameraToWorld,
                                   renderOptions->transformStartTime,
                                   renderOptions->transformEndTime, film);
-    if (!camera) {
-        Error("Unable to create camera.");
-        exit(1);
-    }
     return camera;
 }


### PR DESCRIPTION
This PR fixes handling of missing lenses for the realistic camera #37  and improves overall error handling when loading integrators.

- #37 is resolved by moving the lens file loading and validation outside the constructor and just passing the loaded lens data to it instead. This way we can just return nullptr if we weren't able to read the lens file or it was invalid. Another option is to do the error checking in the constructor but to throw an error in the case of an invalid lens data file and catch this in `CreateRealisticCamera` so we can return nullptr. I'm not sure which would be preferred, let me know if this should change.

- Integrator loading errors are also improved: previously we'd just call `std::exit(1)` which would cause the worker threads to be aborted instead of joined. This is fixed by propagating a load failure of some part of the integrator back to `MakeIntegrator` which then returns nullptr, so we skip rendering the scene and just call `TerminateWorkerThreads` to join the worker threads before exiting.

Let me know if this all looks ok or if anything should be changed. I could squash 0198b96 to clean up the commit history some.