### PR TITLE
add AppVeyor CI for VS2013 and VS2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ pbrt, Version 3
 ===============
 
 [![Build Status](https://travis-ci.org/mmp/pbrt-v3.svg?branch=master)](https://travis-ci.org/mmp/pbrt-v3)
+[![Build status](https://ci.appveyor.com/api/projects/status/hpjwhyo97urew504?svg=true)](https://ci.appveyor.com/project/mwkm/pbrt-v3)
 
 This repository holds the source code to the new version of pbrt that will
 be described in the forthcoming third edition of *Physically Based

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: 1.0.{build}
+branches:
+  only:
+  - appVeyor
+os: 
+- Visual Studio 2013
+- Visual Studio 2015
+configuration: Release
+platform: x64
+clone_folder: c:\pbrt-v3
+install:
+# os detection
+- ps: if ($env:VS140COMNTOOLS -gt 0) { $env:VS_VER = 14 } else { $env:VS_VER = 12 }
+- echo %VS_VER%
+- set PATH=C:\Program Files (x86)\MSBuild\%VS_VER%.0\Bin;%PATH%
+- echo %PATH%
+- git submodule update --init --recursive
+before_build:
+- md c:\pbrt-v3\build
+- cd c:\pbrt-v3\build
+- set WIN32=1
+- ps: if ($env:VS_VER -eq 14) {cmake -G "Visual Studio 14 2015 Win64" ..} else {cmake -G "Visual Studio 12 2013 Win64" ..}
+build:
+  project: c:\pbrt-v3\build\pbrt-v3.sln
+  parallel: true
+  verbosity: normal
+# Quick Hack to force zlib.sln to be built first, Default build failed to do so.
+build_script:
+- msbuild c:\pbrt-v3\build\src\ext\zlib\zlib.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- msbuild c:\pbrt-v3\build\pbrt-v3.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+after_build:
+- cd c:\pbrt-v3\build\Release
+- pbrt_test.exe


### PR DESCRIPTION
CI for Windows platform on AppVeyor, will test on both VS2013 and VS2015.
1. Please edit the badge line in README.MD to point to your own repo.

pbrt compiles fine with VS2015 and pbrttest all OK, awesome !!
VS2013 not happy with alignas() ..... please check my badge to see the whole log.