### PR TITLE
Fix compile errors on MSVC 2013

### DIFF
--- a/src/accelerators/bvh.cpp
+++ b/src/accelerators/bvh.cpp
@@ -618,8 +618,8 @@ BVHBuildNode *BVHAccel::buildUpperSAH(MemoryArena &arena,
     int mid = pmid - &treeletRoots[0];
     Assert(mid > start && mid < end);
     node->InitInterior(
-        dim, buildUpperSAH(arena, treeletRoots, start, mid, totalNodes),
-        buildUpperSAH(arena, treeletRoots, mid, end, totalNodes));
+        dim, this->buildUpperSAH(arena, treeletRoots, start, mid, totalNodes),
+        this->buildUpperSAH(arena, treeletRoots, mid, end, totalNodes));
     return node;
 }
 

--- a/src/core/bssrdf.cpp
+++ b/src/core/bssrdf.cpp
@@ -305,7 +305,7 @@ Spectrum SeparableBSSRDF::Sample_Sp(const Scene &scene, Float u1,
     while (scene.Intersect(base.SpawnRayTo(pTarget), &ptr->si)) {
         base = ptr->si;
         // Append admissible intersection to _IntersectionChain_
-        if (ptr->si.primitive->GetMaterial() == material) {
+        if (ptr->si.primitive->GetMaterial() == this->material) {
             IntersectionChain *next = ARENA_ALLOC(arena, IntersectionChain)();
             ptr->next = next;
             ptr = next;
@@ -320,8 +320,8 @@ Spectrum SeparableBSSRDF::Sample_Sp(const Scene &scene, Float u1,
     *pi = chain->si;
 
     // Compute sample PDF and return the spatial BSSRDF term $\Sp$
-    *pdf = Pdf_Sp(*pi) / nFound;
-    return Sp(*pi);
+    *pdf = this->Pdf_Sp(*pi) / nFound;
+    return this->Sp(*pi);
 }
 
 Float SeparableBSSRDF::Pdf_Sp(const SurfaceInteraction &pi) const {


### PR DESCRIPTION
MSVC 2013 seems to be very peculiar about making certain this-> accesses explicit. This commit adds these and fixes the build under Visual Studio 12.