### PR TITLE
BDPT distant light classification (+ minor stuff)

### DIFF
--- a/src/integrators/bdpt.cpp
+++ b/src/integrators/bdpt.cpp
@@ -209,7 +209,7 @@ Float MISWeight(const Scene &scene, Vertex *lightVertices,
     if (s + t == 2) return 1;
     Float sumRi = 0;
     // Define helper function _remap0_ that deals with Dirac delta functions
-    auto remap0 = [](float f) -> float { return f != 0 ? f : 1; };
+    auto remap0 = [](Float f) -> Float { return f != 0 ? f : 1; };
 
     // Temporarily update vertex properties for current strategy
 

--- a/src/integrators/bdpt.h
+++ b/src/integrators/bdpt.h
@@ -243,7 +243,8 @@ struct Vertex {
     }
     bool IsInfiniteLight() const {
         return type == VertexType::Light &&
-               (!ei.light || ei.light->flags & (int)LightFlags::Infinite);
+               (!ei.light || ei.light->flags & (int)LightFlags::Infinite
+                          || ei.light->flags & (int)LightFlags::DeltaDirection);
     }
     Spectrum Le(const Scene &scene, const Vertex &v) const {
         if (!IsLight()) return Spectrum(0.f);


### PR DESCRIPTION
I finally had some time to look into this, and there was no problem with the MIS code (phew). The problem was that distant light sources were classified as a delta function in the wrong domain, and the patch below fixes this. It also includes a fix for an unrelated CMake issue and a minor typo (float vs Float).