### PR TITLE
Improvements to Windows build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,11 @@ INCLUDE_DIRECTORIES (
   ${CMAKE_BINARY_DIR}/src/ext/openexr/OpenEXR/config
 )
 
-SET(OPENEXR_LIBS IlmImf Imath Half)
+IF(WIN32)
+  SET(OPENEXR_LIBS IlmImf Imath Half zlibstatic)
+ELSE()
+  SET(OPENEXR_LIBS IlmImf Imath Half)
+ENDIF()
 
 SET(WITH_GFLAGS OFF CACHE BOOL "Use gflags")
 SET(BUILD_SHARED_LIBS OFF CACHE BOOL " " FORCE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,7 @@ build:
   project: c:\pbrt-v3\build\pbrt-v3.sln
   parallel: true
   verbosity: normal
-# Quick Hack to force zlib.sln to be built first, Default build failed to do so.
 build_script:
-- msbuild c:\pbrt-v3\build\src\ext\zlib\zlib.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - msbuild c:\pbrt-v3\build\pbrt-v3.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 after_build:
 - cd c:\pbrt-v3\build\Release


### PR DESCRIPTION
Add the missing zlibstatic dependency.
Remove hack from appveyor.yml that explicitly built zlib first.
May fix issue #89?