### PR TITLE
Minor update

### DIFF
--- a/src/core/reflection.cpp
+++ b/src/core/reflection.cpp
@@ -611,8 +611,8 @@ Float FourierBSDF::Pdf(const Vector3f &wo, const Vector3f &wi) const {
     if (!bsdfTable.GetWeightsAndOffset(muI, &offsetI, weightsI) ||
         !bsdfTable.GetWeightsAndOffset(muO, &offsetO, weightsO))
         return 0;
-    Float *ak = ALLOCA(Float, bsdfTable.mMax * bsdfTable.nChannels);
-    memset(ak, 0, bsdfTable.mMax * bsdfTable.nChannels * sizeof(Float));
+    Float *ak = ALLOCA(Float, bsdfTable.mMax);
+    memset(ak, 0, bsdfTable.mMax * sizeof(Float));
     int mMax = 0;
     for (int o = 0; o < 4; ++o) {
         for (int i = 0; i < 4; ++i) {

--- a/src/materials/fourier.cpp
+++ b/src/materials/fourier.cpp
@@ -183,7 +183,9 @@ bool FourierBSDFTable::Read(const std::string &filename,
     }
 
     bsdfTable->recip = new Float[bsdfTable->mMax];
-    for (int i = 0; i < bsdfTable->mMax; ++i)
+    if( bsdfTable->mMax > 0 )
+        bsdfTable->recip[0] = 0.0f;
+    for (int i = 1; i < bsdfTable->mMax; ++i)
         bsdfTable->recip[i] = 1 / (Float)i;
 
     fclose(f);


### PR DESCRIPTION
Avoid dividing by zero case in fourier bsdftable loading pass.
Avoid allocating more memory when evaluating pdf for fourier bsdf.