### PR TITLE
Remove unused FresnelDielectric from GlassMaterial

### DIFF
--- a/src/core/reflection.cpp
+++ b/src/core/reflection.cpp
@@ -514,7 +514,6 @@ std::string FresnelSpecular::ToString() const {
     return std::string("[ FresnelSpecular R: ") + R.ToString() +
            std::string(" T: ") + T.ToString() +
            StringPrintf(" etaA: %f etaB: %f ", etaA, etaB) +
-           std::string(" fresnel: ") + fresnel.ToString() +
            std::string(" mode : ") +
            (mode == TransportMode::Radiance ? std::string("RADIANCE")
                                             : std::string("IMPORTANCE")) +

--- a/src/core/reflection.h
+++ b/src/core/reflection.h
@@ -358,7 +358,6 @@ class FresnelSpecular : public BxDF {
           T(T),
           etaA(etaA),
           etaB(etaB),
-          fresnel(etaA, etaB),
           mode(mode) {}
     Spectrum f(const Vector3f &wo, const Vector3f &wi) const {
         return Spectrum(0.f);
@@ -372,7 +371,6 @@ class FresnelSpecular : public BxDF {
     // FresnelSpecular Private Data
     const Spectrum R, T;
     const Float etaA, etaB;
-    const FresnelDielectric fresnel;
     const TransportMode mode;
 };
 


### PR DESCRIPTION
`GlassMaterial` contains a `FresnelDielectric` member variable but doesn't use it. It uses the `FrDielectric` function directly.