### PR TITLE
Cmake sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,15 +319,6 @@ TARGET_LINK_LIBRARIES ( imgtool
   glog
   )
 
-TARGET_LINK_LIBRARIES ( obj2pbrt
-  pbrt
-  ${CMAKE_THREAD_LIBS_INIT}
-  )
-
-#TARGET_LINK_LIBRARIES ( cyhair2pbrt
-#  ${CMAKE_THREAD_LIBS_INIT}
-#  )
-
 # Unit test
 
 FILE ( GLOB PBRT_TEST_SOURCE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 CMAKE_MINIMUM_REQUIRED ( VERSION 2.8 )
 
+# For sanitizers
+SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
 PROJECT ( PBRT-V3 )
 
 ENABLE_TESTING()
@@ -58,6 +61,7 @@ IF(MSVC)
   ADD_DEFINITIONS (/D YY_NO_UNISTD_H)
 ENDIF()
 
+FIND_PACKAGE ( Sanitizers )
 FIND_PACKAGE ( Threads )
 
 IF(CMAKE_BUILD_TYPE MATCHES RELEASE)
@@ -251,6 +255,7 @@ ADD_LIBRARY ( pbrt STATIC
   ${PBRT_CORE_HEADERS}
   ${PBRT_SOURCE}
   )
+ADD_SANITIZERS ( pbrt )
 
 IF (WIN32)
   # Avoid a name clash when building on Visual Studio
@@ -260,12 +265,11 @@ IF (WIN32)
     )
 ENDIF()
 
-FIND_PACKAGE ( Threads )
-
 # Main renderer
 ADD_EXECUTABLE ( pbrt_exe
   src/main/pbrt.cpp
   )
+ADD_SANITIZERS ( pbrt_exe )
 
 SET_TARGET_PROPERTIES ( pbrt_exe
   PROPERTIES
@@ -279,22 +283,27 @@ TARGET_LINK_LIBRARIES ( pbrt_exe
   glog
   )
 
+
 # Tools
 ADD_EXECUTABLE ( bsdftest
   src/tools/bsdftest.cpp
   )
+ADD_SANITIZERS ( bsdftest )
 
 ADD_EXECUTABLE ( imgtool
   src/tools/imgtool.cpp
   )
+ADD_SANITIZERS ( imgtool )
 
 ADD_EXECUTABLE ( obj2pbrt
   src/tools/obj2pbrt.cpp
   )
+ADD_SANITIZERS ( obj2pbrt )
 
 ADD_EXECUTABLE ( cyhair2pbrt
   src/tools/cyhair2pbrt.cpp
   )
+ADD_SANITIZERS ( cyhair2pbrt )
 
 TARGET_LINK_LIBRARIES ( bsdftest
   pbrt
@@ -315,10 +324,9 @@ TARGET_LINK_LIBRARIES ( obj2pbrt
   ${CMAKE_THREAD_LIBS_INIT}
   )
 
-TARGET_LINK_LIBRARIES ( cyhair2pbrt
-  pbrt
-  ${CMAKE_THREAD_LIBS_INIT}
-  )
+#TARGET_LINK_LIBRARIES ( cyhair2pbrt
+#  ${CMAKE_THREAD_LIBS_INIT}
+#  )
 
 # Unit test
 
@@ -330,6 +338,7 @@ FILE ( GLOB PBRT_TEST_SOURCE
 ADD_EXECUTABLE ( pbrt_test
   ${PBRT_TEST_SOURCE}
   )
+ADD_SANITIZERS ( pbrt_test )
 
 TARGET_LINK_LIBRARIES ( pbrt_test
   pbrt

--- a/cmake/FindASan.cmake
+++ b/cmake/FindASan.cmake
@@ -1,0 +1,59 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # Clang 3.2+ use this version. The no-omit-frame-pointer option is optional.
+    "-g -fsanitize=address -fno-omit-frame-pointer"
+    "-g -fsanitize=address"
+
+    # Older deprecated flag for ASan
+    "-g -faddress-sanitizer"
+)
+
+
+if (SANITIZE_ADDRESS AND (SANITIZE_THREAD OR SANITIZE_MEMORY))
+    message(FATAL_ERROR "AddressSanitizer is not compatible with "
+        "ThreadSanitizer or MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_ADDRESS)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "AddressSanitizer"
+        "ASan")
+
+    find_program(ASan_WRAPPER "asan-wrapper" PATHS ${CMAKE_MODULE_PATH})
+	mark_as_advanced(ASan_WRAPPER)
+endif ()
+
+function (add_sanitize_address TARGET)
+    if (NOT SANITIZE_ADDRESS)
+        return()
+    endif ()
+
+    saitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
+endfunction ()

--- a/cmake/FindMSan.cmake
+++ b/cmake/FindMSan.cmake
@@ -1,0 +1,57 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    "-g -fsanitize=memory"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_MEMORY)
+    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for Linux systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for 64bit systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "MemorySanitizer"
+            "MSan")
+    endif ()
+endif ()
+
+function (add_sanitize_memory TARGET)
+    if (NOT SANITIZE_MEMORY)
+        return()
+    endif ()
+
+    saitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
+endfunction ()

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# If any of the used compiler is a GNU compiler, add a second option to static
+# link against the sanitizers.
+option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)
+
+
+
+
+set(FIND_QUIETLY_FLAG "")
+if (DEFINED Sanitizers_FIND_QUIETLY)
+    set(FIND_QUIETLY_FLAG "QUIET")
+endif ()
+
+find_package(ASan ${FIND_QUIETLY_FLAG})
+find_package(TSan ${FIND_QUIETLY_FLAG})
+find_package(MSan ${FIND_QUIETLY_FLAG})
+find_package(UBSan ${FIND_QUIETLY_FLAG})
+
+
+
+
+function(sanitizer_add_blacklist_file FILE)
+    if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
+    endif()
+    get_filename_component(FILE "${FILE}" REALPATH)
+
+    sanitizer_check_compiler_flags("-fsanitize-blacklist=${FILE}"
+        "SanitizerBlacklist" "SanBlist")
+endfunction()
+
+function(add_sanitizers ...)
+    foreach (TARGET ${ARGV})
+        add_sanitize_address(${TARGET})
+        add_sanitize_thread(${TARGET})
+        add_sanitize_memory(${TARGET})
+        add_sanitize_undefined(${TARGET})
+	endforeach ()
+endfunction(add_sanitizers)

--- a/cmake/FindTSan.cmake
+++ b/cmake/FindTSan.cmake
@@ -1,0 +1,64 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    "-g -fsanitize=thread"
+)
+
+
+# ThreadSanitizer is not compatible with MemorySanitizer.
+if (SANITIZE_THREAD AND SANITIZE_MEMORY)
+    message(FATAL_ERROR "ThreadSanitizer is not compatible with "
+        "MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_THREAD)
+    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+            "ThreadSanitizer is supported for Linux systems only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+            "ThreadSanitizer is supported for 64bit systems only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "ThreadSanitizer"
+            "TSan")
+    endif ()
+endif ()
+
+function (add_sanitize_thread TARGET)
+    if (NOT SANITIZE_THREAD)
+        return()
+    endif ()
+
+    saitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
+endfunction ()

--- a/cmake/FindUBSan.cmake
+++ b/cmake/FindUBSan.cmake
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_UNDEFINED
+    "Enable UndefinedBehaviorSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    "-g -fsanitize=undefined"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_UNDEFINED)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}"
+        "UndefinedBehaviorSanitizer" "UBSan")
+endif ()
+
+function (add_sanitize_undefined TARGET)
+    if (NOT SANITIZE_UNDEFINED)
+        return()
+    endif ()
+
+    saitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
+endfunction ()

--- a/cmake/asan-wrapper
+++ b/cmake/asan-wrapper
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This script is a wrapper for AddressSanitizer. In some special cases you need
+# to preload AddressSanitizer to avoid error messages - e.g. if you're
+# preloading another library to your application. At the moment this script will
+# only do something, if we're running on a Linux platform. OSX might not be
+# affected.
+
+
+# Exit immediately, if platform is not Linux.
+if [ "$(uname)" != "Linux" ]
+then
+    exec $@
+fi
+
+
+# Get the used libasan of the application ($1). If a libasan was found, it will
+# be prepended to LD_PRELOAD.
+libasan=$(ldd $1 | grep libasan | sed "s/^[[:space:]]//" | cut -d' ' -f1)
+if [ -n "$libasan" ]
+then
+    if [ -n "$LD_PRELOAD" ]
+    then
+        export LD_PRELOAD="$libasan:$LD_PRELOAD"
+    else
+        export LD_PRELOAD="$libasan"
+    fi
+fi
+
+# Execute the application.
+exec $@

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -1,0 +1,173 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Helper function to get the language of a source file.
+function (sanitizer_lang_of_source FILE RETURN_VAR)
+    get_filename_component(FILE_EXT "${FILE}" EXT)
+    string(TOLOWER "${FILE_EXT}" FILE_EXT)
+    string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+        if (NOT ${TEMP} EQUAL -1)
+            set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach()
+
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get compilers used by a target.
+function (sanitizer_target_compilers TARGET RETURN_VAR)
+    # Check if all sources for target use the same compiler. If a target uses
+    # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+    # gfortran) this can trigger huge problems, because different compilers may
+    # use different implementations for sanitizers.
+    set(BUFFER "")
+    get_target_property(TSOURCES ${TARGET} SOURCES)
+    foreach (FILE ${TSOURCES})
+        # If expression was found, FILE is a generator-expression for an object
+        # library. Object libraries will be ignored.
+        string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+        if ("${_file}" STREQUAL "")
+            sanitizer_lang_of_source(${FILE} LANG)
+            if (LANG)
+                list(APPEND BUFFER ${CMAKE_${LANG}_COMPILER_ID})
+            endif ()
+        endif ()
+    endforeach ()
+
+    list(REMOVE_DUPLICATES BUFFER)
+    set(${RETURN_VAR} "${BUFFER}" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to check compiler flags for language compiler.
+function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
+    if (${LANG} STREQUAL "C")
+        include(CheckCCompilerFlag)
+        check_c_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "CXX")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "Fortran")
+        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be compatible
+        # with older Cmake versions, we will check if this module is present
+        # before we use it. Otherwise we will define Fortran coverage support as
+        # not available.
+        include(CheckFortranCompilerFlag OPTIONAL RESULT_VARIABLE INCLUDED)
+        if (INCLUDED)
+            check_fortran_compiler_flag("${FLAG}" ${VARIABLE})
+        elseif (NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing Test ${VARIABLE}")
+            message(STATUS "Performing Test ${VARIABLE}"
+                " - Failed (Check not supported)")
+        endif ()
+    endif()
+endfunction ()
+
+
+# Helper function to test compiler flags.
+function (sanitizer_check_compiler_flags FLAG_CANDIDATES NAME PREFIX)
+    set(CMAKE_REQUIRED_QUIET ${${PREFIX}_FIND_QUIETLY})
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        # Sanitizer flags are not dependend on language, but the used compiler.
+        # So instead of searching flags foreach language, search flags foreach
+        # compiler used.
+        set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+        if (NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
+            foreach (FLAG ${FLAG_CANDIDATES})
+                if(NOT CMAKE_REQUIRED_QUIET)
+                    message(STATUS "Try ${COMPILER} ${NAME} flag = [${FLAG}]")
+                endif()
+
+                set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+                unset(${PREFIX}_FLAG_DETECTED CACHE)
+                sanitizer_check_compiler_flag("${FLAG}" ${LANG}
+                    ${PREFIX}_FLAG_DETECTED)
+
+                if (${PREFIX}_FLAG_DETECTED)
+                    # If compiler is a GNU compiler, search for static flag, if
+                    # SANITIZE_LINK_STATIC is enabled.
+                    if (SANITIZE_LINK_STATIC AND (${COMPILER} STREQUAL "GNU"))
+                        string(TOLOWER ${PREFIX} PREFIX_lower)
+                        sanitizer_check_compiler_flag(
+                            "-static-lib${PREFIX_lower}" ${LANG}
+                            ${PREFIX}_STATIC_FLAG_DETECTED)
+
+                        if (${PREFIX}_STATIC_FLAG_DETECTED)
+                            set(FLAG "-static-lib${PREFIX_lower} ${FLAG}")
+                        endif ()
+                    endif ()
+
+                    set(${PREFIX}_${COMPILER}_FLAGS "${FLAG}" CACHE STRING
+                        "${NAME} flags for ${COMPILER} compiler.")
+                    mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+                    break()
+                endif ()
+            endforeach ()
+
+            if (NOT ${PREFIX}_FLAG_DETECTED)
+                set(${PREFIX}_${COMPILER}_FLAGS "" CACHE STRING
+                    "${NAME} flags for ${COMPILER} compiler.")
+                mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+            endif ()
+        endif ()
+    endforeach ()
+endfunction ()
+
+
+# Helper to assign sanitizer flags for TARGET.
+function (saitizer_add_flags TARGET NAME PREFIX)
+    # Get list of compilers used by target and check, if target can be checked
+    # by sanitizer.
+    sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+    list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+    if (NUM_COMPILERS GREATER 1)
+        message(WARNING "${NAME} disabled for target ${TARGET} because it will "
+            "be compiled by different compilers.")
+        return()
+
+    elseif ((NUM_COMPILERS EQUAL 0) OR
+        ("${${PREFIX}_${TARGET_COMPILER}_FLAGS}" STREQUAL ""))
+        message(WARNING "${NAME} disabled for target ${TARGET} because there is"
+            " no sanitizer available for target sources.")
+        return()
+    endif()
+
+    # Set compile- and link-flags for target.
+    set_property(TARGET ${TARGET} APPEND_STRING
+        PROPERTY COMPILE_FLAGS " ${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    set_property(TARGET ${TARGET} APPEND_STRING
+        PROPERTY COMPILE_FLAGS " ${SanBlist_${TARGET_COMPILER}_FLAGS}")
+    set_property(TARGET ${TARGET} APPEND_STRING
+        PROPERTY LINK_FLAGS " ${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+endfunction ()


### PR DESCRIPTION
This PR enables sanitizers support for `pbrt` using this cmake modules: https://github.com/arsenm/sanitizers-cmake

With `-DSANITIZE_ADDRESS=On`, it now can find buffer overflow and invalid memory access for example:

```
 $ ./pbrt_test 
Running main() from gtest_main.cc
=================================================================
==24651==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffd4d6451f0 at pc 0x000000868a12 bp 0x7ffd4d644e30 sp 0x7ffd4d644e20
WRITE of size 1 at 0x7ffd4d6451f0 thread T0
    #0 0x868a11 in std::char_traits<char>::assign(char&, char const&) /usr/include/c++/5/bits/char_traits.h:243
    #1 0x868a11 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::push_back(char) /usr/include/c++/5/bits/basic_string.h:1083
    #2 0x868a11 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator+=(char) /usr/include/c++/5/bits/basic_string.h:961
    #3 0x868a11 in pbrt::copyToFormatString(char const**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /home/syoyo/work/pbrt-v3/src/core/stringprint.h:75
    #4 0x868a11 in void pbrt::stringPrintfRecursive<int, int, float>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, char const*, int, int, float) /home/syoyo/work/pbrt-v3/src/core/stringprint.h:120
    #5 0x868a11 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > pbrt::StringPrintf<int, int, float>(char const*, int, int, float) /home/syoyo/work/pbrt-v3/src/core/stringprint.h:169
    #6 0x868a11 in pbrt::BVHAccel::BVHAccel(std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > > const&, int, pbrt::BVHAccel::SplitMethod) /home/syoyo/work/pbrt-v3/src/accelerators/bvh.cpp:209
    #7 0x55bc09 in void __gnu_cxx::new_allocator<pbrt::BVHAccel>::construct<pbrt::BVHAccel, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(pbrt::BVHAccel*, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/ext/new_allocator.h:120
    #8 0x55bc09 in void std::allocator_traits<std::allocator<pbrt::BVHAccel> >::construct<pbrt::BVHAccel, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::allocator<pbrt::BVHAccel>&, pbrt::BVHAccel*, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/alloc_traits.h:530
    #9 0x55bc09 in std::_Sp_counted_ptr_inplace<pbrt::BVHAccel, std::allocator<pbrt::BVHAccel>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::allocator<pbrt::BVHAccel>, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr_base.h:522
    #10 0x55bc09 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<pbrt::BVHAccel, std::allocator<pbrt::BVHAccel>, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::_Sp_make_shared_tag, pbrt::BVHAccel*, std::allocator<pbrt::BVHAccel> const&, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr_base.h:617
    #11 0x55bc09 in std::__shared_ptr<pbrt::BVHAccel, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<pbrt::BVHAccel>, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::_Sp_make_shared_tag, std::allocator<pbrt::BVHAccel> const&, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr_base.h:1097
    #12 0x543fdf in std::shared_ptr<pbrt::BVHAccel>::shared_ptr<std::allocator<pbrt::BVHAccel>, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::_Sp_make_shared_tag, std::allocator<pbrt::BVHAccel> const&, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr.h:319
    #13 0x543fdf in std::shared_ptr<pbrt::BVHAccel> std::allocate_shared<pbrt::BVHAccel, std::allocator<pbrt::BVHAccel>, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::allocator<pbrt::BVHAccel> const&, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr.h:620
    #14 0x543fdf in std::shared_ptr<pbrt::BVHAccel> std::make_shared<pbrt::BVHAccel, std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&>(std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > >&) /usr/include/c++/5/bits/shared_ptr.h:636
    #15 0x543fdf in GetScenes() /home/syoyo/work/pbrt-v3/src/tests/analytic_scenes.cpp:87
    #16 0x547277 in GetIntegrators() /home/syoyo/work/pbrt-v3/src/tests/analytic_scenes.cpp:273
    #17 0x5514e7 in gtest_AnalyticTestScenesRenderTest_EvalGenerator_() /home/syoyo/work/pbrt-v3/src/tests/analytic_scenes.cpp:435
    #18 0x55e8e0 in testing::internal::ParameterizedTestCaseInfo<RenderTest>::RegisterTests() /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest.h:10498
    #19 0x5cdbc5 in testing::internal::ParameterizedTestCaseRegistry::RegisterTests() /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest.h:10605
    #20 0x5cdbc5 in testing::internal::UnitTestImpl::RegisterParameterizedTests() /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest-all.cc:3774
    #21 0x5cdbc5 in testing::internal::UnitTestImpl::PostFlagParsingInit() /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest-all.cc:5609
    #22 0x5e34b2 in testing::internal::UnitTestImpl::PostFlagParsingInit() /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest-all.cc:5598
    #23 0x5e34b2 in void testing::internal::InitGoogleTestImpl<char>(int*, char**) /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest-all.cc:6475
    #24 0x4b2d57 in main /home/syoyo/work/pbrt-v3/src/tests/gtest/gtest_main.cc:39
    #25 0x7fef5b40b82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #26 0x4bdf28 in _start (/mnt/centos6-home/syoyo/work/pbrt-v3/build/pbrt_test+0x4bdf28)

Address 0x7ffd4d6451f0 is located in stack of thread T0 at offset 688 in frame
    #0 0x86574f in pbrt::BVHAccel::BVHAccel(std::vector<std::shared_ptr<pbrt::Primitive>, std::allocator<std::shared_ptr<pbrt::Primitive> > > const&, int, pbrt::BVHAccel::SplitMethod) /home/syoyo/work/pbrt-v3/src/accelerators/bvh.cpp:183

AddressSanitizer can't parse the stack frame descriptor: |15 64 4 10 totalNodes 128 4 6 offset 192 4 2 v1 256 4 2 v2 320 8 7 _result 384 24 13 primitiveInfo 448 24 12 orderedPrims 512 128 5 arena 704 0 9 <unknown> 736 32 7 nextFmt 800 32 9 <unknown> 864 32 7 nextFmt 928 32 9 <unknown> 992 32 7 nextFmt 1056 32 9 <unknown> |
SUMMARY: AddressSanitizer: stack-buffer-overflow /usr/include/c++/5/bits/char_traits.h:243 std::char_traits<char>::assign(char&, char const&)
Shadow bytes around the buggy address:
  0x100029ac09e0: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1 f1 f1
  0x100029ac09f0: 04 f4 f4 f4 f2 f2 f2 f2 04 f4 f4 f4 f2 f2 f2 f2
  0x100029ac0a00: 04 f4 f4 f4 f2 f2 f2 f2 04 f4 f4 f4 f2 f2 f2 f2
  0x100029ac0a10: 00 f4 f4 f4 f2 f2 f2 f2 00 00 00 f4 f2 f2 f2 f2
  0x100029ac0a20: 00 00 00 f4 f2 f2 f2 f2 00 00 00 00 00 00 00 00
=>0x100029ac0a30: 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2 f2[f2]f2
  0x100029ac0a40: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
  0x100029ac0a50: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
  0x100029ac0a60: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
  0x100029ac0a70: f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
  0x100029ac0a80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==24651==ABORTING
```


