### PR TITLE
Add z coordinate check about refraction (#92)

### DIFF
--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -126,7 +126,8 @@ bool RealisticCamera::TraceLensesFromFilm(const Ray &rCamera, Ray *rOut) const {
             Float etaT = (i > 0 && elementInterfaces[i - 1].eta != 0)
                              ? elementInterfaces[i - 1].eta
                              : 1;
-            if (!Refract(Normalize(-rLens.d), n, etaI / etaT, &w)) return false;
+            if (!Refract(Normalize(-rLens.d), n, etaI / etaT, &w) || w.z > 0)
+                return false;
             rLens.d = w;
         }
     }


### PR DESCRIPTION
I investigated the issue (#92).
As a result, I found that the boundary condition in refraction is the cause.

The following figure shows incident and refract rays at 6th lens element. 
eta_I is 1.617 and eta_T is 1. Therefore, the refraction seems to be correct (or it may be total reflection).
However, the z direction of W_t is positive and the assertion failed.
![figure_1](https://cloud.githubusercontent.com/assets/8927943/23589722/906d46b6-0215-11e7-837a-f9e2f76246ca.png)

Although I do not know whether such rays actually exist or they are due to computational errors, to solve this issue I simply added a condition to check the direction of the ray.
