### PR TITLE
Add assertion to avoid passing negative value to sqrt().

### DIFF
--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -452,9 +452,10 @@ Float RealisticCamera::FocusThickLens(Float focusDistance) {
     // Compute translation of lens, _delta_, to focus at _focusDistance_
     Float f = fz[0] - pz[0];
     Float z = -focusDistance;
+    Float c = (pz[1] - z - pz[0]) * (pz[1] - z * 4 * f - pz[0]);
+    CHECK_GT(c, 0) << "Coefficient must be positive. It looks focusDistance: " << focusDistance << " is too short for a given lenses configuration";
     Float delta =
-        0.5f * (pz[1] - z + pz[0] -
-                std::sqrt((pz[1] - z - pz[0]) * (pz[1] - z - 4 * f - pz[0])));
+        0.5f * (pz[1] - z + pz[0] - std::sqrt(c));
     return elementInterfaces.back().thickness + delta;
 }
 


### PR DESCRIPTION
When `focusdistance` is too short, `delta` in `FocusThickLens` become NaN  since  negative value is passed to `sqrt`.

This PR ensures positive value is passed to `sqrt`

The situation can be reproduced by setting `focusdistance` to `0.05` in `dragons.pbrt` example scene.

```
Camera "realistic"
        "string lensfile" "lenses/wide.22mm.dat"
        "float aperturediameter" 8.756
        "float focusdistance" .05
```