### PR TITLE
Better focus ray search

### DIFF
--- a/src/cameras/realistic.cpp
+++ b/src/cameras/realistic.cpp
@@ -493,10 +493,9 @@ Float RealisticCamera::FocusDistance(Float filmDistance) {
 
     Ray ray;
 
-    // Try some different (decreasing) scaling factor to find focus ray
-    // For example, when aperture stop is too small(e.g. 2 [mm] in
-    // dgauss.50mm.dat),
-    // `0.1` will fail to find focus ray, but `0.01` will success.
+    // Try some different and decreasing scaling factor to find focus ray
+    // more quickly when `aperturediameter` is too small.
+    // (e.g. 2 [mm] for `aperturediameter` with wide.22mm.dat),
     bool foundFocusRay = false;
     for (auto &scale : scaleFactors) {
         lu = scale * bounds.pMax[0];


### PR DESCRIPTION
`clang-format` did some code reformat, but the core of change is here: https://github.com/mmp/pbrt-v3/compare/master...syoyo:better-focus-ray-search?expand=1#diff-2ca607d646ef4f24ea00346f9144205fL486

The situation can be reproduced  in dragons.pbrt scene,  by setting `aperturediameter` smaller and `focusdistance` shorter like this.

```
Camera "realistic"
        "string lensfile" "lenses/wide.22mm.dat"
        "float aperturediameter" 2
        "float focusdistance" .2
```

In this situation, it fails to find focus ray thus focusing takes too much time.

This PR tries to use different scaling factor for finding focus ray more quickly when aperturediameter is too small.