### PR TITLE
Fixed imgtool diff saving.

### DIFF
--- a/src/tools/imgtool.cpp
+++ b/src/tools/imgtool.cpp
@@ -413,7 +413,7 @@ int diff(int argc, char *argv[]) {
             if (d > .005) ++smallDiff;
             if (d > .05) ++bigDiff;
         }
-        if (diffImage) diffImage[i].FromRGB(diffRGB);
+        if (diffImage) diffImage[i] = RGBSpectrum::FromRGB(diffRGB);
     }
 
     double avg[2] = {sum[0] / (3. * res[0].x * res[0].y),


### PR DESCRIPTION
RGBSpectrum::FromRGB is a static function, not a mutator method, so we need to explicitly write into the diffImage array.