### PR TITLE
Fixed a minor bug in the warning message of sobol sampler. 

### DIFF
--- a/src/samplers/sobol.h
+++ b/src/samplers/sobol.h
@@ -54,7 +54,7 @@ class SobolSampler : public GlobalSampler {
         if (!IsPowerOf2(samplesPerPixel))
             Warning("Non power-of-two sample count rounded up to %" PRId64
                     " for SobolSampler.",
-                    samplesPerPixel);
+                    this->samplesPerPixel);
         resolution = RoundUpPow2(
             std::max(sampleBounds.Diagonal().x, sampleBounds.Diagonal().y));
         log2Resolution = Log2Int(resolution);


### PR DESCRIPTION
In sobol.h the local variable _samplesPerPixel_ shadows the member variable with the same name. The warning then prints the local variable instead of the rounded-up member variable.

For example:

    W0729 11:00:38.111961 3391042496 error.cpp:87] scene.pbrt(45): Non power-of-two sample count rounded up to 200 for SobolSampler.

This patch fixes the issue by referencing the member variable.
 