### PR TITLE
Fix unit test for print utility.

### DIFF
--- a/src/tests/print.cpp
+++ b/src/tests/print.cpp
@@ -15,7 +15,7 @@ TEST(StringPrintf, Basics) {
     EXPECT_EQ(StringPrintf("%f, %f, %f", 1., 1.5, -8.125),
               "1, 1.5, -8.125");
 #ifndef NDEBUG
-    EXPECT_DEATH(StringPrintf("not enough %s"), "Assertion.*failed.*line");
+    EXPECT_DEATH(StringPrintf("not enough %s"), ".*Check failed: .*");
 #endif
 }
 


### PR DESCRIPTION
The original testcase is broken. It seems that [the assertion in `stringPrintfRecursive` has been changed to glog provided version](https://github.com/mmp/pbrt-v3/commit/514194f8b2d6b549c22c1c7e886dfc46f92bcad6#diff-ab43ead0d0c058632de4c5808e286bcc) but the testing is not updated as well.

This is the only broken testcase on MacOS. Hope to fix it soon. By the way, I still do not consider that it is a good phenomenon to let the success of testing relies on the behavior of an external library.