### PR TITLE
Make the parser use file memory-mapping on Windows too.

### DIFF
--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -282,7 +282,7 @@ string_view Tokenizer::Next() {
         } else if (ch == '#') {
             // comment: scan to EOL (or EOF)
             while ((ch = getChar()) != EOF) {
-                if (ch == '\n') {
+                if (ch == '\n' || ch == '\r') {
                     ungetChar();
                     break;
                 }

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -47,6 +47,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#elif defined(PBRT_IS_WINDOWS)
+#include <windows.h> // Windows file mapping API
 #endif  // PBRT_HAVE_MMAP
 #include <functional>
 #include <iostream>
@@ -130,19 +132,55 @@ std::unique_ptr<Tokenizer> Tokenizer::CreateFromFile(
     // return std::make_unique<Tokenizer>(ptr, len);
     return std::unique_ptr<Tokenizer>(
         new Tokenizer(ptr, len, filename, std::move(errorCallback)));
-#else
-    // TODO: it would be nice to also memory map the file if this is Windows...
-    FILE *f = fopen(filename.c_str(), "r");
-    if (!f) {
-        errorCallback(
-            StringPrintf("%s: %s", filename.c_str(), strerror(errno)).c_str());
-        return nullptr;
-    }
+#elif defined(PBRT_IS_WINDOWS)
+	auto errorReportLambda = [&errorCallback, &filename]() ->std::unique_ptr<Tokenizer> {
+		LPSTR messageBuffer = nullptr;
+		FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, ::GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
 
-    std::string str;
-    int ch;
-    while ((ch = fgetc(f)) != EOF) str.push_back(char(ch));
-    fclose(f);
+		errorCallback(
+			StringPrintf("%s: %s", filename.c_str(), messageBuffer).c_str());
+
+		LocalFree(messageBuffer);
+		return nullptr;
+	};
+
+	HANDLE fileHandle = CreateFileA(filename.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+	if (!fileHandle) {
+		return errorReportLambda();
+	}
+
+	size_t len = GetFileSize(fileHandle, 0);
+
+	HANDLE mapping = CreateFileMapping(fileHandle, 0, PAGE_READONLY, 0, 0, 0);
+	CloseHandle(fileHandle);
+	if (mapping == 0) {
+		return errorReportLambda();
+	}
+
+	LPVOID ptr = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+	CloseHandle(mapping);
+	if (ptr == nullptr) {
+		return errorReportLambda();
+	}
+
+	std::string str(static_cast<const char*>(ptr), len);
+
+	return std::unique_ptr<Tokenizer>(
+		new Tokenizer(ptr, len, filename, std::move(errorCallback)));
+#else
+	FILE *f = fopen(filename.c_str(), "r");
+	if (!f) {
+		errorCallback(
+			StringPrintf("%s: %s", filename.c_str(), strerror(errno)).c_str());
+		return nullptr;
+	}
+
+	std::string str;
+	int ch;
+	while ((ch = fgetc(f)) != EOF) str.push_back(char(ch));
+	fclose(f);
+
     // std::make_unique...
     return std::unique_ptr<Tokenizer>(
         new Tokenizer(std::move(str), std::move(errorCallback)));
@@ -166,7 +204,7 @@ Tokenizer::Tokenizer(std::string str,
     tokenizerMemory += contents.size();
 }
 
-#ifdef PBRT_HAVE_MMAP
+#if defined(PBRT_HAVE_MMAP) || defined(PBRT_IS_WINDOWS)
 Tokenizer::Tokenizer(void *ptr, size_t len, std::string filename,
                      std::function<void(const char *)> errorCallback)
     : loc(filename),
@@ -183,6 +221,16 @@ Tokenizer::~Tokenizer() {
     if (unmapPtr && unmapLength > 0)
         if (munmap(unmapPtr, unmapLength) != 0)
             errorCallback(StringPrintf("munmap: %s", strerror(errno)).c_str());
+#elif defined(PBRT_IS_WINDOWS)
+	if (unmapPtr) {
+		if (UnmapViewOfFile(unmapPtr) == 0) {
+			LPSTR messageBuffer = nullptr;
+			FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+				NULL, ::GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+			errorCallback(StringPrintf("UnmapViewOfFile: %s", messageBuffer).c_str());
+			LocalFree(messageBuffer);
+		}
+	}
 #endif
 }
 

--- a/src/core/parser.h
+++ b/src/core/parser.h
@@ -118,7 +118,7 @@ class Tokenizer {
 
   private:
     Tokenizer(std::string str, std::function<void(const char *)> errorCallback);
-#ifdef PBRT_HAVE_MMAP
+#if defined(PBRT_HAVE_MMAP) || defined(PBRT_IS_WINDOWS)
     Tokenizer(void *ptr, size_t len, std::string filename,
               std::function<void(const char *)> errorCallback);
 #endif
@@ -144,7 +144,7 @@ class Tokenizer {
     // This function is called if there is an error during lexing.
     std::function<void(const char *)> errorCallback;
 
-#ifdef PBRT_HAVE_MMAP
+#if defined(PBRT_HAVE_MMAP) || defined(PBRT_IS_WINDOWS)
     // Scene files on disk are mapped into memory for lexing.  We need to
     // hold on to the starting pointer and total length so they can be
     // unmapped in the destructor.

--- a/src/tests/parser.cpp
+++ b/src/tests/parser.cpp
@@ -118,10 +118,14 @@ Integrator "deep" "float density" [ 2 2.66612 -5e-51]
     auto err = [](const char *err) {
         EXPECT_TRUE(false) << "Unexpected error: " << err;
     };
-    auto t = Tokenizer::CreateFromFile(filename, err);
-    ASSERT_TRUE(t.get() != nullptr);
-    checkTokens(t.get(), {"WorldBegin", "# hello", "Integrator", "\"deep\"", "\"float density\"",
-                          "[", "2", "2.66612", "-5e-51", "]"});
+	// Windows won't let us remove the file on disk if we hold on to a mapping view.
+	// So enclose the tokenizer in a scope so that it releases any file mapping view before the remove.
+	{
+		auto t = Tokenizer::CreateFromFile(filename, err);
+		ASSERT_TRUE(t.get() != nullptr);
+		checkTokens(t.get(), { "WorldBegin", "# hello", "Integrator", "\"deep\"", "\"float density\"",
+			"[", "2", "2.66612", "-5e-51", "]" });
+	}
 
     EXPECT_EQ(0, remove(filename.c_str()));
 }


### PR DESCRIPTION
Some thoughts on this:

- Maybe I should have changed the PBRT_HAVE_MMAP define name. But since mmap doesn't exist on Windows, still makes sense.
- I kept the "slurping all characters from file" method if we don't have mmap AND we aren't on Windows (never, basically ?). But otherwise, if we failed to memory-map the file, we error and exit. Perhaps it would be best to fallback on the manual file open and read in all cases if memory mapping fails.

I could only test on my personal Windows 10, sorry!. But as it's pretty classic windows API, I expect this to work smoothly with older versions of Windows.