### PR TITLE
Bug fix for TransformCache

### DIFF
--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -290,8 +290,8 @@ class TransformCache {
 
     void Clear() {
         transformCacheBytes += arena.TotalAllocated() + hashTable.size() * sizeof(Transform *);
-        hashTable.resize(512);
         hashTable.clear();
+        hashTable.resize(512);
         hashTableOccupancy = 0;
         arena.Reset();
     }


### PR DESCRIPTION
`hashTable.resize(512)` should be done after `hashTable.clear()`, otherwise the size of the hash table will be 0 after `Clear` is called. When pbrt is compiled as a library, this would lead to crash in multiple rendering passes.