### PR TITLE
Removed unused baseColor texture

### DIFF
--- a/src/materials/disney.h
+++ b/src/materials/disney.h
@@ -87,7 +87,7 @@ class DisneyMaterial : public Material {
   private:
     // DisneyMaterial Private Data
     std::shared_ptr<Texture<Spectrum>> color;
-    std::shared_ptr<Texture<Float>> baseColor, metallic, eta;
+    std::shared_ptr<Texture<Float>> metallic, eta;
     std::shared_ptr<Texture<Float>> roughness, specularTint, anisotropic, sheen;
     std::shared_ptr<Texture<Float>> sheenTint, clearcoat, clearcoatGloss;
     std::shared_ptr<Texture<Float>> specTrans;


### PR DESCRIPTION
The single channel `baseColor` texture is already "replaced" by the n-channel `color` texture. Note that `base color` is the actual terminology used by Burley.