### PR TITLE
ScopedAssignment: move assignment operator

### DIFF
--- a/src/integrators/bdpt.h
+++ b/src/integrators/bdpt.h
@@ -100,6 +100,7 @@ class ScopedAssignment {
     ScopedAssignment(const ScopedAssignment &) = delete;
     ScopedAssignment &operator=(const ScopedAssignment &) = delete;
     ScopedAssignment &operator=(ScopedAssignment &&other) {
+        if (target) *target = backup;
         target = other.target;
         backup = other.backup;
         other.target = nullptr;


### PR DESCRIPTION
Recover the backup of the old instance before monitoring the new instance.