### PR TITLE
Improve numerical behavior of Sphere::Sample()

### DIFF
--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -251,27 +251,36 @@ Interaction Sphere::Sample(const Interaction &ref, const Point2f &u,
         return intr;
     }
 
-    // Compute coordinate system for sphere sampling
-    Vector3f wc = Normalize(pCenter - ref.p);
-    Vector3f wcX, wcY;
-    CoordinateSystem(wc, &wcX, &wcY);
-
     // Sample sphere uniformly inside subtended cone
 
     // Compute $\theta$ and $\phi$ values for sample in cone
-    Float sinThetaMax2 = radius * radius / DistanceSquared(ref.p, pCenter);
-    Float cosThetaMax = std::sqrt(std::max((Float)0, 1 - sinThetaMax2));
-    Float cosTheta = (1 - u[0]) + u[0] * cosThetaMax;
-    Float sinTheta = std::sqrt(std::max((Float)0, 1 - cosTheta * cosTheta));
-    Float phi = u[1] * 2 * Pi;
+
+    Float invDc          = 1.f / Distance(ref.p, pCenter),
+          sinThetaMax    = radius * invDc,
+          sinThetaMax2   = sinThetaMax * sinThetaMax,
+          invSinThetaMax = 1.f / sinThetaMax,
+          cosThetaMax    = std::sqrt(std::max(0.f, 1.f - sinThetaMax2));
+
+    Float cosTheta  = (cosThetaMax - 1.f) * u[0] + 1.f,
+          sinTheta2 = 1.f - cosTheta*cosTheta;
+
+    if (sinThetaMax2 < 0.00068523f /* sin^2(1.5 deg) */) {
+        /* Fall back to a Taylor series expansion for small angles, where
+           the standard approach suffers from severe cancellation errors */
+        sinTheta2 = sinThetaMax2 * u[0];
+        cosTheta = std::sqrt(1.f - sinTheta2);
+    }
 
     // Compute angle $\alpha$ from center of sphere to sampled point on surface
-    Float dc = Distance(ref.p, pCenter);
-    Float ds = dc * cosTheta -
-               std::sqrt(std::max(
-                   (Float)0, radius * radius - dc * dc * sinTheta * sinTheta));
-    Float cosAlpha = (dc * dc + radius * radius - ds * ds) / (2 * dc * radius);
-    Float sinAlpha = std::sqrt(std::max((Float)0, 1 - cosAlpha * cosAlpha));
+    Float cosAlpha = sinTheta2 * invSinThetaMax +
+                     cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2*invSinThetaMax*invSinThetaMax)),
+          sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha)),
+          phi = u[1] * 2 * Pi;
+
+    // Compute coordinate system for sphere sampling
+    Vector3f wc = (pCenter - ref.p) * invDc;
+    Vector3f wcX, wcY;
+    CoordinateSystem(wc, &wcX, &wcY);
 
     // Compute surface normal and sampled point on sphere
     Vector3f nWorld =


### PR DESCRIPTION
The current implementation of ``Sphere::Sample()`` computes ``sinTheta``
from ``cosTheta`` using the expression
``std::sqrt(1-sinTheta*sinTheta)``.

While convenient and computationally cheap, this approach suffers from
severe cancellation errors for small angles, causing the sphere to
effectively collapse down to a point. Numerical errors start to kick in
below ``sinThetaMax`` < 1.5 degrees in single precision.

As far as numerical issues go, this isn't that terrible — a point light
is a relatively good approximation to a distant sphere. Yet, 1.5 degrees
seems relatively large and we can easily do better by computing
``sinTheta`` directly using a Taylor series expansion. This commit
introduces such an approximation and also reorganizes the computation to
be a bit more efficient.