### PR TITLE
Modify sphere.cpp for compiling by gcc with PBRT_FLOAT_AS_DOUBLE option.

### DIFF
--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -264,7 +264,7 @@ Interaction Sphere::Sample(const Interaction &ref, const Point2f &u,
     Float sinThetaMax = radius * invDc;
     Float sinThetaMax2 = sinThetaMax * sinThetaMax;
     Float invSinThetaMax = 1 / sinThetaMax;
-    Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
+    Float cosThetaMax = std::sqrt(std::max((Float)0.f, 1 - sinThetaMax2));
 
     Float cosTheta  = (cosThetaMax - 1) * u[0] + 1;
     Float sinTheta2 = 1 - cosTheta * cosTheta;
@@ -278,8 +278,8 @@ Interaction Sphere::Sample(const Interaction &ref, const Point2f &u,
 
     // Compute angle $\alpha$ from center of sphere to sampled point on surface
     Float cosAlpha = sinTheta2 * invSinThetaMax +
-        cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
-    Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
+        cosTheta * std::sqrt(std::max((Float)0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
+    Float sinAlpha = std::sqrt(std::max((Float)0.f, 1.f - cosAlpha*cosAlpha));
     Float phi = u[1] * 2 * Pi;
 
     // Compute surface normal and sampled point on sphere


### PR DESCRIPTION
Hi!
I fixed compile error on gcc when PBRT_FLOAT_AS_DOUBLE enabled.
Test environment is gcc (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5) on Amazon Linux.

Before modification, Some type cast errors occurred as follows.
So, I add type cast explicitly.

-----
```sh
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp: In member function ‘virtual pbrt::Interaction pbrt::Sphere::Sample(const pbrt::Interaction&, const Point2f&, pbrt::Float*) const’:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:267:65: error: no matching function for call to ‘max(float, pbrt::Float)’
     Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
                                                                 ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:219:5: note: candidate: template<class _Tp> const _Tp& std::max(const _Tp&, const _Tp&)
     max(const _Tp& __a, const _Tp& __b)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:219:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:267:65: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
     Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
                                                                 ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:265:5: note: candidate: template<class _Tp, class _Compare> const _Tp& std::max(const _Tp&, const _Tp&, _Compare)
     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:265:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:267:65: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
     Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
                                                                 ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3462:5: note: candidate: template<class _Tp> _Tp std::max(std::initializer_list<_Tp>)
     max(initializer_list<_Tp> __l)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3462:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:267:65: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
     Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
                                                                 ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3468:5: note: candidate: template<class _Tp, class _Compare> _Tp std::max(std::initializer_list<_Tp>, _Compare)
     max(initializer_list<_Tp> __l, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3468:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:267:65: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
     Float cosThetaMax = std::sqrt(std::max(0.f, 1 - sinThetaMax2));
                                                                 ^
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:281:93: error: no matching function for call to ‘max(float, pbrt::Float)’
         cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
                                                                                             ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:219:5: note: candidate: template<class _Tp> const _Tp& std::max(const _Tp&, const _Tp&)
     max(const _Tp& __a, const _Tp& __b)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:219:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:281:93: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
         cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
                                                                                             ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:265:5: note: candidate: template<class _Tp, class _Compare> const _Tp& std::max(const _Tp&, const _Tp&, _Compare)
     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:265:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:281:93: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
         cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
                                                                                             ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3462:5: note: candidate: template<class _Tp> _Tp std::max(std::initializer_list<_Tp>)
     max(initializer_list<_Tp> __l)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3462:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:281:93: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
         cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
                                                                                             ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3468:5: note: candidate: template<class _Tp, class _Compare> _Tp std::max(std::initializer_list<_Tp>, _Compare)
     max(initializer_list<_Tp> __l, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3468:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:281:93: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
         cosTheta * std::sqrt(std::max(0.f, 1.f - sinTheta2 * invSinThetaMax * invSinThetaMax));
                                                                                             ^
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:282:69: error: no matching function for call to ‘max(float, pbrt::Float)’
     Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
                                                                     ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:219:5: note: candidate: template<class _Tp> const _Tp& std::max(const _Tp&, const _Tp&)
     max(const _Tp& __a, const _Tp& __b)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:219:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:282:69: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
     Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
                                                                     ^
In file included from /usr/include/c++/7/algorithm:61:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algobase.h:265:5: note: candidate: template<class _Tp, class _Compare> const _Tp& std::max(const _Tp&, const _Tp&, _Compare)
     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algobase.h:265:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:282:69: note:   deduced conflicting types for parameter ‘const _Tp’ (‘float’ and ‘pbrt::Float {aka double}’)
     Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
                                                                     ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3462:5: note: candidate: template<class _Tp> _Tp std::max(std::initializer_list<_Tp>)
     max(initializer_list<_Tp> __l)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3462:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:282:69: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
     Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
                                                                     ^
In file included from /usr/include/c++/7/algorithm:62:0,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/pbrt.h:44,
                 from /home/ec2-user/workspace/pbrt-v3/src/core/shape.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.h:42,
                 from /home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:35:
/usr/include/c++/7/bits/stl_algo.h:3468:5: note: candidate: template<class _Tp, class _Compare> _Tp std::max(std::initializer_list<_Tp>, _Compare)
     max(initializer_list<_Tp> __l, _Compare __comp)
     ^~~
/usr/include/c++/7/bits/stl_algo.h:3468:5: note:   template argument deduction/substitution failed:
/home/ec2-user/workspace/pbrt-v3/src/shapes/sphere.cpp:282:69: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘float’
     Float sinAlpha = std::sqrt(std::max(0.f, 1.f - cosAlpha*cosAlpha));
```
-----

Best regards,