### PR TITLE
Fix a param in hit point calculation

### DIFF
--- a/src/shapes/curve.cpp
+++ b/src/shapes/curve.cpp
@@ -365,7 +365,7 @@ bool Curve::recursiveIntersect(const Ray &ray, Float *tHit,
                 dpdv = rayToObject(dpdvPlane);
             }
             *isect = (*ObjectToWorld)(SurfaceInteraction(
-                ray(pc.z), pError, Point2f(u, v), -ray.d, dpdu, dpdv,
+                ray(*tHit), pError, Point2f(u, v), -ray.d, dpdu, dpdv,
                 Normal3f(0, 0, 0), Normal3f(0, 0, 0), ray.time, this));
         }
         ++nHits;


### PR DESCRIPTION
sorry for my poor english~.
I have some confuse at the code *isect = (*ObjectToWorld)(SurfaceInteraction( ray(pc.z), pError, Point2f(u, v), -ray.d, dpdu, dpdv, Normal3f(0, 0, 0), Normal3f(0, 0, 0), ray.time, this)); in line 367 of curve.cpp.
the hit point is eq ray(pc.z) here,but i think is's ray((*tHit)) but not ray(pc.z) because the pc.z is not eq *tHit if the length of ray is not normalized.