### PR TITLE
Fixing ResampleLinearSpectrum method in spectrum.cpp

### DIFF
--- a/src/core/spectrum.cpp
+++ b/src/core/spectrum.cpp
@@ -1267,7 +1267,7 @@ void ResampleLinearSpectrum(const Float *lambdaIn, const Float *vIn, int nIn,
             // Linear search from the starting point. (Presumably more
             // efficient than a binary search from scratch, or doesn't
             // matter either way.)
-            end = start;
+            end = start > 0 ? start : 0;
             while (end < nIn && lambda + delta > lambdaIn[end]) ++end;
         }
 


### PR DESCRIPTION
I debugged and tested this with VS2019 16.1.3.

The problem was an index out of bounds problem where end would be -1.
This worked on all Configurations but "Release" for me. Somehow the compiler flag /Ob (Inline Function Expansion) on level 2 did something different than on level 1. (Test was working on level 1)
The access to lambdaIn[-1] returned -nan in "Release" (with /Ob2) but an tiny tiny value in all other Configurations.
I just made sure that end should never be smaller than null. Now all tests seem to work.

I didn't investigate further what the EXACT problem was, this would take too long for me now. If anyone knows the itty bitty details, please let me know.

Cheers,
Stefan