### PR TITLE
core/parser: remove used members and parameters.

### DIFF
--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -387,7 +387,6 @@ struct ParamListItem {
     double *doubleValues = nullptr;
     const char **stringValues = nullptr;
     size_t size = 0;
-    bool isString = false;
 };
 
 PBRT_CONSTEXPR int TokenOptional = 0;


### PR DESCRIPTION
It would appear the `SpectrumType` isn't used anywhere in the new hand-rolled parser.  As a reader, I found it confusing that it is set to different values, but not used.  Are they supposed to be used? If no, please consider this pull request to remove them.

Additionally I removed the `isString` member on `ParamListItem`.  I think it is vestigial, as you end up checking if `item.stringValues` or `item.doubleValues` was set in `AddParam` as an alternative to determining if the parameter is a string.