### PR TITLE
Fix index clamping bug in MarbleTexture

### DIFF
--- a/src/textures/marble.h
+++ b/src/textures/marble.h
@@ -71,8 +71,8 @@ class MarbleTexture : public Texture<Spectrum> {
             {.58f, .58f, .6f}, {.2f, .2f, .33f},  {.58f, .58f, .6f},
         };
 #define NC sizeof(c) / sizeof(c[0])
-#define NSEG (NC - 3)
-        int first = std::min(1, int(std::floor(t * NSEG)));
+#define NSEG int(NC - 3)
+        int first = std::min(NSEG - 1, int(std::floor(t * NSEG)));
         t = (t * NSEG - first);
         Spectrum c0 = Spectrum::FromRGB(c[first]);
         Spectrum c1 = Spectrum::FromRGB(c[first + 1]);


### PR DESCRIPTION
This also fixes MarbleTexture so that they render properly again since t also ends up being miscomputed as a consequence of the incorrect clamping.

Issue #252